### PR TITLE
feat: add client_id support for config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,4 +42,5 @@ provider "xelon" {
 ### Optional
 
 - `base_url` (String) The base URL endpoint for Xelon HQ. Default is 'https://hq.xelon.ch/api/service/'.
+- `client_id` (String) The client ID for IP ranges.
 - `token` (String) The Xelon access token.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Xelon-AG/terraform-provider-xelon
 go 1.19
 
 require (
-	github.com/Xelon-AG/xelon-sdk-go v0.7.1-0.20221221031726-f779ea760ee0
+	github.com/Xelon-AG/xelon-sdk-go v0.10.0
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C67SkzkDfmQuVln04ygHj3vjZfd9FL+GmQQ=
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
-github.com/Xelon-AG/xelon-sdk-go v0.7.1-0.20221221031726-f779ea760ee0 h1:2nv7bWsVYZt/0ArDxwRmYdOw53MBVSaxcACj1y8JEBY=
-github.com/Xelon-AG/xelon-sdk-go v0.7.1-0.20221221031726-f779ea760ee0/go.mod h1:IMPzHhqE/9ws6FsjPCgPHeyS0F4nMXMn/iyHDB+KVYk=
+github.com/Xelon-AG/xelon-sdk-go v0.10.0 h1:VggnnExKVekgHGCV81yD66wvWOzZeN4MCu6b4p3ZKJQ=
+github.com/Xelon-AG/xelon-sdk-go v0.10.0/go.mod h1:2T0CJNTsFsOSz2/aW05OvldzVU3bqd/vpzaOiH34sHE=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=

--- a/internal/xelon/config.go
+++ b/internal/xelon/config.go
@@ -9,6 +9,7 @@ import (
 // Config is configuration defined in the provider block.
 type Config struct {
 	BaseURL         string
+	ClientID        string
 	Token           string
 	ProviderVersion string
 }
@@ -16,6 +17,10 @@ type Config struct {
 func (c *Config) Client() *xelon.Client {
 	opts := []xelon.ClientOption{xelon.WithUserAgent(c.userAgent())}
 	opts = append(opts, xelon.WithBaseURL(c.BaseURL))
+
+	if c.ClientID != "" {
+		opts = append(opts, xelon.WithClientID(c.ClientID))
+	}
 
 	client := xelon.NewClient(c.Token, opts...)
 

--- a/internal/xelon/provider.go
+++ b/internal/xelon/provider.go
@@ -17,6 +17,12 @@ func New(version string) func() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("XELON_BASE_URL", "https://hq.xelon.ch/api/service/"),
 				Description: "The base URL endpoint for Xelon HQ. Default is 'https://hq.xelon.ch/api/service/'.",
 			},
+			"client_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("XELON_CLIENT_ID", nil),
+				Description: "The client ID for IP ranges.",
+			},
 			"token": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -43,6 +49,7 @@ func New(version string) func() *schema.Provider {
 func providerConfigure(_ context.Context, d *schema.ResourceData, version string) (interface{}, diag.Diagnostics) {
 	config := &Config{
 		BaseURL:         d.Get("base_url").(string),
+		ClientID:        d.Get("client_id").(string),
 		Token:           d.Get("token").(string),
 		ProviderVersion: version,
 	}

--- a/internal/xelon/resource_xelon_device.go
+++ b/internal/xelon/resource_xelon_device.go
@@ -233,7 +233,7 @@ func resourceXelonDeviceDelete(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func fetchTenant(ctx context.Context, client *xelon.Client) (*xelon.Tenant, error) {
-	tenant, _, err := client.Tenant.Get(ctx)
+	tenant, _, err := client.Tenants.GetCurrent(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("getting tenant information: %w", err)
 	}


### PR DESCRIPTION
This PR allows to configure `client_id` by provider configuration and use it for IP ranges.

```hcl
provider "xelon" {
  client_id = "<client-id>"
  token = "<some-secret-token>"
}
```