### PR TITLE
chore: add sweepers to cleanup leftover infrastructure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,7 +68,7 @@ jobs:
     name: acceptance tests (terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     needs: build
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       XELON_BASE_URL: ${{ secrets.XELON_BASE_URL }}
       XELON_CLIENT_ID: ${{ secrets.XELON_CLIENT_ID }}
@@ -112,6 +112,37 @@ jobs:
 
       - name: Run acceptance tests
         run: make testacc
+
+  sweeper:
+    name: sweeper cleanup
+    runs-on: ubuntu-latest
+    needs: acceptance-tests
+    timeout-minutes: 15
+    env:
+      XELON_BASE_URL: ${{ secrets.XELON_BASE_URL }}
+      XELON_CLIENT_ID: ${{ secrets.XELON_CLIENT_ID }}
+      XELON_TOKEN: ${{ secrets.XELON_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+
+      - name: Set up cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum', 'tools/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run sweeper cleanup
+        run: make sweep
 
   docs:
     name: documentation

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,14 @@ testacc:
 	@mkdir -p $(BUILD_DIR)
 	@TF_ACC=1 go test -count=1 -v -cover -coverprofile=$(BUILD_DIR)/coverage-with-acceptance.out -parallel=4 -timeout 120m ./...
 
+## sweep: Run sweepers to cleanup leftover infrastructure after acceptance tests.
+.PHONY: sweep
+sweep:
+	@echo "==> Running sweepers to cleanup leftover infrastructure..."
+	@echo "    WARNING: This will destroy infrastructure. Use only in development accounts."
+	@echo ""
+	@go test -count=1 -v ./internal/xelon -sweep=vdcnew
+
 ## build: Build provider for default local system's operating system and architecture.
 .PHONY: build
 build:

--- a/internal/xelon/xelon_sweeper_test.go
+++ b/internal/xelon/xelon_sweeper_test.go
@@ -1,0 +1,35 @@
+package xelon
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/Xelon-AG/xelon-sdk-go/xelon"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
+func sharedClient(_ string) (*xelon.Client, error) {
+	if v := os.Getenv("XELON_BASE_URL"); v == "" {
+		return nil, fmt.Errorf("empty XELON_BASE_URL")
+	}
+	if v := os.Getenv("XELON_CLIENT_ID"); v == "" {
+		return nil, fmt.Errorf("empty XELON_CLIENT_ID")
+	}
+	if v := os.Getenv("XELON_TOKEN"); v == "" {
+		return nil, fmt.Errorf("empty XELON_TOKEN")
+	}
+
+	config := &Config{
+		BaseURL:         os.Getenv("XELON_BASE_URL"),
+		ClientID:        os.Getenv("XELON_CLIENT_ID"),
+		Token:           os.Getenv("XELON_TOKEN"),
+		ProviderVersion: "sweeper",
+	}
+
+	return config.Client(), nil
+}


### PR DESCRIPTION
This PR adds sweepers support to cleanup leftover infrastructure after acceptance tests.
https://developer.hashicorp.com/terraform/plugin/sdkv2/testing/acceptance-tests/sweepers