### PR TITLE
chore: replace deprecated GoReleaser options

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -4,6 +4,7 @@ archives:
       - README.md
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    rlcp: true
 
 before:
   hooks:
@@ -19,10 +20,10 @@ builds:
       - arm
       - arm64
     goos:
-      - freebsd
-      - windows
-      - linux
       - darwin
+      - freebsd
+      - linux
+      - windows
     ignore:
       - goos: darwin
         goarch: '386'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: release --config .github/goreleaser.yaml --rm-dist --release-notes=.release/DRAFT.md
+          args: release --config .github/goreleaser.yaml --clean --release-notes=.release/DRAFT.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
This PR replace deprecated GoReleaser options: `rm-dist` and `archive.rlcp`.

Fixes #18