### PR TITLE
feat: compose sdkv2 and framework providers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     xelon = {
       source  = "Xelon-AG/xelon"
-      version = ">= 0.1.0"
+      version = ">= 0.7.0"
     }
   }
 }
@@ -41,6 +41,6 @@ provider "xelon" {
 
 ### Optional
 
-- `base_url` (String) The base URL endpoint for Xelon HQ. Default is 'https://hq.xelon.ch/api/service/'.
-- `client_id` (String) The client ID for IP ranges.
-- `token` (String) The Xelon access token.
+- `base_url` (String) The base URL endpoint for Xelon HQ. Default is `https://hq.xelon.ch/api/service/`. Alternatively, can be configured using the `XELON_BASE_URL` environment variable.
+- `client_id` (String) The client ID for IP ranges. Alternatively, can be configured using the `XELON_CLIENT_ID` environment variable.
+- `token` (String) The Xelon access token. Alternatively, can be configured using the `XELON_TOKEN` environment variable.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     xelon = {
       source  = "Xelon-AG/xelon"
-      version = ">= 0.1.0"
+      version = ">= 0.7.0"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.19
 
 require (
 	github.com/Xelon-AG/xelon-sdk-go v0.12.1
+	github.com/hashicorp/terraform-plugin-framework v1.1.1
+	github.com/hashicorp/terraform-plugin-go v0.14.3
 	github.com/hashicorp/terraform-plugin-log v0.8.0
+	github.com/hashicorp/terraform-plugin-mux v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/stretchr/testify v1.8.1
 )
@@ -31,7 +34,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.17.3 // indirect
 	github.com/hashicorp/terraform-json v0.15.0 // indirect
-	github.com/hashicorp/terraform-plugin-go v0.14.3 // indirect
 	github.com/hashicorp/terraform-registry-address v0.1.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -108,10 +108,14 @@ github.com/hashicorp/terraform-exec v0.17.3 h1:MX14Kvnka/oWGmIkyuyvL6POx25ZmKrjl
 github.com/hashicorp/terraform-exec v0.17.3/go.mod h1:+NELG0EqQekJzhvikkeQsOAZpsw0cv/03rbeQJqscAI=
 github.com/hashicorp/terraform-json v0.15.0 h1:/gIyNtR6SFw6h5yzlbDbACyGvIhKtQi8mTsbkNd79lE=
 github.com/hashicorp/terraform-json v0.15.0/go.mod h1:+L1RNzjDU5leLFZkHTFTbJXaoqUC6TqXlFgDoOXrtvk=
+github.com/hashicorp/terraform-plugin-framework v1.1.1 h1:PbnEKHsIU8KTTzoztHQGgjZUWx7Kk8uGtpGMMc1p+oI=
+github.com/hashicorp/terraform-plugin-framework v1.1.1/go.mod h1:DyZPxQA+4OKK5ELxFIIcqggcszqdWWUpTLPHAhS/tkY=
 github.com/hashicorp/terraform-plugin-go v0.14.3 h1:nlnJ1GXKdMwsC8g1Nh05tK2wsC3+3BL/DBBxFEki+j0=
 github.com/hashicorp/terraform-plugin-go v0.14.3/go.mod h1:7ees7DMZ263q8wQ6E4RdIdR6nHHJtrdt4ogX5lPkX1A=
 github.com/hashicorp/terraform-plugin-log v0.8.0 h1:pX2VQ/TGKu+UU1rCay0OlzosNKe4Nz1pepLXj95oyy0=
 github.com/hashicorp/terraform-plugin-log v0.8.0/go.mod h1:1myFrhVsBLeylQzYYEV17VVjtG8oYPRFdaZs7xdW2xs=
+github.com/hashicorp/terraform-plugin-mux v0.9.0 h1:a2Xh63cunDB/1GZECrV02cGA74AhQGUjY9X8W3P/L7k=
+github.com/hashicorp/terraform-plugin-mux v0.9.0/go.mod h1:8NUFbgeMigms7Tma/r2Vgi5Jv5mPv4xcJ05pJtIOhwc=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0 h1:iNRjaJCatQS1rIbHs/vDvJ0GECsaGgxx780chA2Irpk=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0/go.mod h1:XnVNLIS6bdMJbjSDujhX4Rlk24QpbGKbnrVFM4tZ7OU=
 github.com/hashicorp/terraform-registry-address v0.1.0 h1:W6JkV9wbum+m516rCl5/NjKxCyTVaaUBbzYcMzBDO3U=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,141 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/Xelon-AG/xelon-sdk-go/xelon"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+const (
+	defaultBaseURL = "https://hq.xelon.ch/api/service/"
+)
+
+var _ provider.Provider = (*xelonProvider)(nil)
+
+// xelonProvider defines the provider implementation.
+type xelonProvider struct {
+	// version is set to
+	//  - the provider version on release
+	//  - "dev" when the provider is built and ran locally
+	//  - "testacc" when running acceptance tests
+	version string
+}
+
+func New(version string) func() provider.Provider {
+	return func() provider.Provider {
+		return &xelonProvider{
+			version: version,
+		}
+	}
+}
+
+func (p *xelonProvider) Metadata(_ context.Context, _ provider.MetadataRequest, response *provider.MetadataResponse) {
+	response.TypeName = "xelon"
+	response.Version = p.version
+}
+
+func (p *xelonProvider) Schema(_ context.Context, _ provider.SchemaRequest, response *provider.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"base_url": schema.StringAttribute{
+				Optional: true,
+				Description: fmt.Sprintf("The base URL endpoint for Xelon HQ. Default is `%s`. "+
+					"Alternatively, can be configured using the `XELON_BASE_URL` environment variable.", defaultBaseURL),
+			},
+
+			"client_id": schema.StringAttribute{
+				Optional: true,
+				Description: "The client ID for IP ranges. Alternatively, can be configured " +
+					"using the `XELON_CLIENT_ID` environment variable.",
+			},
+
+			"token": schema.StringAttribute{
+				Optional: true,
+				Description: "The Xelon access token. Alternatively, can be configured " +
+					"using the `XELON_TOKEN` environment variable.",
+			},
+		},
+	}
+}
+
+type providerModel struct {
+	BaseURL  types.String `tfsdk:"base_url"`
+	ClientID types.String `tfsdk:"client_id"`
+	Token    types.String `tfsdk:"token"`
+}
+
+func (p *xelonProvider) Configure(ctx context.Context, request provider.ConfigureRequest, response *provider.ConfigureResponse) {
+	var config providerModel
+
+	diags := request.Config.Get(ctx, &config)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// fallback to env if unset
+	if config.BaseURL.IsNull() {
+		if baseURLFromEnv, ok := os.LookupEnv("XELON_BASE_URL"); ok {
+			config.BaseURL = types.StringValue(baseURLFromEnv)
+		} else {
+			config.BaseURL = types.StringValue(defaultBaseURL)
+		}
+	}
+	if config.ClientID.IsNull() {
+		config.ClientID = types.StringValue(os.Getenv("XELON_CLIENT_ID"))
+	}
+	if config.Token.IsNull() {
+		config.Token = types.StringValue(os.Getenv("XELON_TOKEN"))
+	}
+
+	// required if still unset
+	if config.Token.ValueString() == "" {
+		response.Diagnostics.AddAttributeError(
+			path.Root("token"),
+			"Invalid provider config",
+			"token must be set.",
+		)
+		return
+	}
+
+	// build xelon sdk client
+	opts := []xelon.ClientOption{xelon.WithUserAgent(p.userAgent())}
+	opts = append(opts, xelon.WithBaseURL(config.BaseURL.ValueString()))
+	if config.ClientID.ValueString() != "" {
+		opts = append(opts, xelon.WithClientID(config.ClientID.ValueString()))
+	}
+	client := xelon.NewClient(config.Token.ValueString(), opts...)
+
+	tflog.Info(ctx, "Xelon SDK client configured", map[string]interface{}{
+		"base_url":          config.BaseURL.ValueString(),
+		"client_id":         config.ClientID.ValueString(),
+		"terraform_version": request.TerraformVersion,
+	})
+
+	response.DataSourceData = client
+	response.ResourceData = client
+}
+
+func (p *xelonProvider) DataSources(_ context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}
+
+func (p *xelonProvider) Resources(_ context.Context) []func() resource.Resource {
+	return []func() resource.Resource{}
+}
+
+func (p *xelonProvider) userAgent() string {
+	name := "terraform-provider-xelon"
+	comment := "https://registry.terraform.io/providers/Xelon-AG/xelon"
+
+	return fmt.Sprintf("%s/%s (+%s)", name, p.version, comment)
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvider_userAgent(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		version           string
+		expectedUserAgent string
+	}
+	tests := map[string]testCase{
+		"empty_version": {
+			version:           "",
+			expectedUserAgent: "terraform-provider-xelon/ (+https://registry.terraform.io/providers/Xelon-AG/xelon)",
+		},
+		"dev_version": {
+			version:           "dev",
+			expectedUserAgent: "terraform-provider-xelon/dev (+https://registry.terraform.io/providers/Xelon-AG/xelon)",
+		},
+		"release_version": {
+			version:           "1.1.1",
+			expectedUserAgent: "terraform-provider-xelon/1.1.1 (+https://registry.terraform.io/providers/Xelon-AG/xelon)",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := &xelonProvider{version: test.version}
+			actualUserAgent := p.userAgent()
+
+			assert.Equal(t, test.expectedUserAgent, actualUserAgent)
+		})
+	}
+}

--- a/internal/xelon/provider.go
+++ b/internal/xelon/provider.go
@@ -15,19 +15,22 @@ func New(version string) func() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("XELON_BASE_URL", "https://hq.xelon.ch/api/service/"),
-				Description: "The base URL endpoint for Xelon HQ. Default is 'https://hq.xelon.ch/api/service/'.",
+				Description: "The base URL endpoint for Xelon HQ. Default is `https://hq.xelon.ch/api/service/`. " +
+					"Alternatively, can be configured using the `XELON_BASE_URL` environment variable.",
 			},
 			"client_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("XELON_CLIENT_ID", nil),
-				Description: "The client ID for IP ranges.",
+				Description: "The client ID for IP ranges. Alternatively, can be configured " +
+					"using the `XELON_CLIENT_ID` environment variable.",
 			},
 			"token": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("XELON_TOKEN", nil),
-				Description: "The Xelon access token.",
+				Description: "The Xelon access token. Alternatively, can be configured " +
+					"using the `XELON_TOKEN` environment variable.",
 			},
 		},
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,17 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
+	"context"
+	"flag"
+	"log"
 
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+
+	"github.com/Xelon-AG/terraform-provider-xelon/internal/provider"
 	"github.com/Xelon-AG/terraform-provider-xelon/internal/xelon"
 )
 
@@ -11,7 +20,39 @@ var (
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: xelon.New(version),
-	})
+	var debugMode bool
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with debug support")
+	flag.Parse()
+
+	ctx := context.Background()
+
+	upgradedSDKProvider, err := tf5to6server.UpgradeServer(ctx, xelon.New(version)().GRPCProvider)
+	if err != nil {
+		log.Fatal(err)
+	}
+	providers := []func() tfprotov6.ProviderServer{
+		func() tfprotov6.ProviderServer {
+			return upgradedSDKProvider
+		},
+		providerserver.NewProtocol6(provider.New(version)()),
+	}
+
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var serveOpts []tf6server.ServeOpt
+	if debugMode {
+		serveOpts = append(serveOpts, tf6server.WithManagedDebug())
+	}
+
+	err = tf6server.Serve(
+		"registry.terraform.io/Xelon-AG/xelon",
+		muxServer.ProviderServer,
+		serveOpts...,
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -2,7 +2,7 @@
   "version": 1,
   "metadata": {
     "protocol_versions": [
-      "5.0"
+      "6.0"
     ]
   }
 }


### PR DESCRIPTION
This PR adds following capabilities:
- [x] upgrade existing provider protocol to version v6
- [x] serve the SDKv2 version of the provider as a v6 compatible server
- [x] add the newer framework server with matching provider configuration scheme
- [x] multiplex the two together as a single interface for consumers

## Links
- #21 