### PR TITLE
fix(datasource/xelon_cloud): add cloud type attribute

### DIFF
--- a/docs/data-sources/cloud.md
+++ b/docs/data-sources/cloud.md
@@ -47,3 +47,7 @@ data "xelon_cloud" "hcp" {
 
 - `id` (String) The ID of the cloud.
 - `name` (String) The cloud name.
+
+### Read-Only
+
+- `type` (String) The type of the cloud.

--- a/internal/provider/data_source_xelon_cloud.go
+++ b/internal/provider/data_source_xelon_cloud.go
@@ -26,6 +26,7 @@ type cloudDataSource struct {
 type cloudDataSourceModel struct {
 	ID   types.String `tfsdk:"id"`
 	Name types.String `tfsdk:"name"`
+	Type types.String `tfsdk:"type"`
 }
 
 func NewCloudDataSource() datasource.DataSource {
@@ -53,6 +54,10 @@ Xelon cloud is data center where your resources are hosted.
 				MarkdownDescription: "The cloud name.",
 				Computed:            true,
 				Optional:            true,
+			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "The type of the cloud.",
+				Computed:            true,
 			},
 		},
 	}
@@ -97,7 +102,7 @@ func (d *cloudDataSource) Read(ctx context.Context, request datasource.ReadReque
 	tflog.Debug(ctx, "Getting clouds")
 	clouds, _, err := d.client.Clouds.List(ctx, nil)
 	if err != nil {
-		response.Diagnostics.AddError("Unable to list clouds", err.Error())
+		response.Diagnostics.AddError("Unable to get clouds", err.Error())
 		return
 	}
 	tflog.Debug(ctx, "Got clouds", map[string]any{"data": clouds})
@@ -138,6 +143,7 @@ func (d *cloudDataSource) Read(ctx context.Context, request datasource.ReadReque
 	// map response body to attributes
 	data.ID = types.StringValue(cloud.ID)
 	data.Name = types.StringValue(cloud.Name)
+	data.Type = types.StringValue(cloud.Type)
 
 	diags = response.State.Set(ctx, &data)
 	response.Diagnostics.Append(diags...)

--- a/internal/provider/data_source_xelon_cloud_test.go
+++ b/internal/provider/data_source_xelon_cloud_test.go
@@ -1,0 +1,46 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccDataSourceXelonCloud(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceXelonCloudConfig,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"data.xelon_cloud.test",
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"data.xelon_cloud.test",
+						tfjsonpath.New("type"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"data.xelon_cloud.test",
+						tfjsonpath.New("name"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+		},
+	})
+}
+
+const testAccDataSourceXelonCloudConfig = `
+data "xelon_cloud" "test" {
+  # cloud id from test environment, change if updated
+  id = "c9ab2f0fcfde"
+}
+`


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds `type` attribute for `xelon_cloud` datasource. Acceptance tests will use new statecheck functions.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
