### PR TITLE
chore(goreleaser): exclude windows_arm_6 from builds

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -28,6 +28,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: windows
+        goarm: 6
     ldflags:
       - "-s -w -X main.version={{.Version}}"
     mod_timestamp: '{{ .CommitTimestamp }}'


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR excludes `windows_arm_6` from build targets in GoReleaser and solves the warning
> broken target, use at your own risk              target=windows_arm_6

https://github.com/Xelon-AG/terraform-provider-xelon/actions/runs/19689661765/job/56402643529#step:7:24

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
