### PR TITLE
fix(datasource/xelon_tenant): add parent and type attributes

### DIFF
--- a/docs/data-sources/tenant.md
+++ b/docs/data-sources/tenant.md
@@ -58,4 +58,6 @@ data "xelon_tenant" "team" {
 
 ### Read-Only
 
+- `parent_tenant_id` (String) The ID of the parent tenant.
 - `status` (String) The status of the tenant.
+- `type` (String) The type of the tenant (`Reseller` or `End Customer`).

--- a/internal/provider/data_source_xelon_tenant.go
+++ b/internal/provider/data_source_xelon_tenant.go
@@ -25,9 +25,11 @@ type tenantDataSource struct {
 
 // tenantDataSourceModel maps the tenant datasource schema data.
 type tenantDataSourceModel struct {
-	ID     types.String `tfsdk:"id"`
-	Name   types.String `tfsdk:"name"`
-	Status types.String `tfsdk:"status"`
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	ParentTenantID types.String `tfsdk:"parent_tenant_id"`
+	Status         types.String `tfsdk:"status"`
+	Type           types.String `tfsdk:"type"`
 }
 
 func NewTenantDataSource() datasource.DataSource {
@@ -57,8 +59,16 @@ to group resources and manage access.
 				Computed:            true,
 				Optional:            true,
 			},
+			"parent_tenant_id": schema.StringAttribute{
+				MarkdownDescription: "The ID of the parent tenant.",
+				Computed:            true,
+			},
 			"status": schema.StringAttribute{
 				MarkdownDescription: "The status of the tenant.",
+				Computed:            true,
+			},
+			"type": schema.StringAttribute{
+				MarkdownDescription: "The type of the tenant (`Reseller` or `End Customer`).",
 				Computed:            true,
 			},
 		},
@@ -109,7 +119,9 @@ func (d *tenantDataSource) Read(ctx context.Context, request datasource.ReadRequ
 		// map response body to attributes
 		data.ID = types.StringValue(tenant.ID)
 		data.Name = types.StringValue(tenant.Name)
+		data.ParentTenantID = types.StringValue(tenant.Parent)
 		data.Status = types.StringValue(tenant.Status)
+		data.Type = types.StringValue(tenant.Type)
 	}
 
 	if tenantID != "" {
@@ -139,7 +151,9 @@ func (d *tenantDataSource) Read(ctx context.Context, request datasource.ReadRequ
 		// map response body to attributes
 		data.ID = types.StringValue(tenant.ID)
 		data.Name = types.StringValue(tenant.Name)
+		data.ParentTenantID = types.StringValue(tenant.Parent)
 		data.Status = types.StringValue(tenant.Status)
+		data.Type = types.StringValue(tenant.Type)
 	} else if tenantName != "" {
 		tflog.Info(ctx, "Searching for tenant by name", map[string]any{"tenant_name": tenantName})
 
@@ -167,7 +181,9 @@ func (d *tenantDataSource) Read(ctx context.Context, request datasource.ReadRequ
 		tenant := &tenants[0]
 		data.ID = types.StringValue(tenant.ID)
 		data.Name = types.StringValue(tenant.Name)
+		data.ParentTenantID = types.StringValue(tenant.Parent)
 		data.Status = types.StringValue(tenant.Status)
+		data.Type = types.StringValue(tenant.Type)
 	}
 
 	diags = response.State.Set(ctx, &data)


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR adds `type` and `parent_tenant_id` attributes for `xelon_tenant` datasource.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
