### PR TITLE
fix(xelon_iso): use status field for checking readiness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Xelon-AG/terraform-provider-xelon
 go 1.25
 
 require (
-	github.com/Xelon-AG/xelon-sdk-go v1.1.0
+	github.com/Xelon-AG/xelon-sdk-go v1.1.1
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Xelon-AG/xelon-sdk-go v1.1.0 h1:+vyfYXqiI9AAoKplzEgP0TXHN7F4pxHAOn1EkbixAbM=
-github.com/Xelon-AG/xelon-sdk-go v1.1.0/go.mod h1:w+Wn4vz22E5nSxWxdRhZLeJEqhWn98Pt5krH3WF6AkA=
+github.com/Xelon-AG/xelon-sdk-go v1.1.1 h1:NvUV1yzv3RLEWJyOjp0reUnIytr0C0iyEstJpQypzr0=
+github.com/Xelon-AG/xelon-sdk-go v1.1.1/go.mod h1:w+Wn4vz22E5nSxWxdRhZLeJEqhWn98Pt5krH3WF6AkA=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/provider/helper/iso_status.go
+++ b/internal/provider/helper/iso_status.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	isoStateActive   = "active"
-	isoStateInactive = "inactive"
+	isoStateCreating = "creating"
+	isoStateReady    = "ready"
 )
 
 func statusISOState(ctx context.Context, client *xelon.Client, isoID string) retry.StateRefreshFunc {
@@ -23,7 +23,7 @@ func statusISOState(ctx context.Context, client *xelon.Client, isoID string) ret
 			// API returns 500 sometimes for fresh created ISOs
 			tflog.Info(ctx, "error by getting ISO", map[string]any{"response": resp})
 			if resp != nil && resp.StatusCode == http.StatusInternalServerError {
-				return iso, isoStateInactive, nil
+				return iso, isoStateCreating, nil
 			}
 			return nil, "", err
 		}
@@ -32,10 +32,10 @@ func statusISOState(ctx context.Context, client *xelon.Client, isoID string) ret
 		}
 
 		var isoState string
-		if iso.Active {
-			isoState = isoStateActive
+		if iso.Status {
+			isoState = isoStateReady
 		} else {
-			isoState = isoStateInactive
+			isoState = isoStateCreating
 		}
 
 		return iso, isoState, nil

--- a/internal/provider/helper/iso_wait.go
+++ b/internal/provider/helper/iso_wait.go
@@ -10,10 +10,10 @@ import (
 	"github.com/Xelon-AG/xelon-sdk-go/xelon"
 )
 
-func WaitISOActive(ctx context.Context, client *xelon.Client, isoID string) error {
+func WaitISOStateReady(ctx context.Context, client *xelon.Client, isoID string) error {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{isoStateInactive},
-		Target:     []string{isoStateActive},
+		Pending:    []string{isoStateCreating},
+		Target:     []string{isoStateReady},
 		Timeout:    10 * time.Minute,
 		MinTimeout: 5 * time.Second,
 		Delay:      3 * time.Second,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -46,8 +46,6 @@ func TestProvider_MissingTokenAttribute(t *testing.T) {
 }
 
 func TestProvider_userAgent(t *testing.T) {
-	t.Parallel()
-
 	type testCase struct {
 		version           string
 		expectedUserAgent string

--- a/internal/provider/resource_xelon_iso.go
+++ b/internal/provider/resource_xelon_iso.go
@@ -152,13 +152,13 @@ func (r *isoResource) Create(ctx context.Context, request resource.CreateRequest
 	tflog.Debug(ctx, "Created ISO", map[string]any{"data": iso})
 
 	isoID := iso.ID
-	tflog.Info(ctx, "Waiting for ISO to be active", map[string]any{"iso_id": isoID})
-	err = helper.WaitISOActive(ctx, r.client, isoID)
+	tflog.Info(ctx, "Waiting for ISO to be ready", map[string]any{"iso_id": isoID})
+	err = helper.WaitISOStateReady(ctx, r.client, isoID)
 	if err != nil {
-		response.Diagnostics.AddError("Unable to wait for ISO to be active", err.Error())
+		response.Diagnostics.AddError("Unable to wait for ISO to be ready", err.Error())
 		return
 	}
-	tflog.Info(ctx, "ISO is active", map[string]any{"iso_id": isoID})
+	tflog.Info(ctx, "ISO is ready", map[string]any{"iso_id": isoID})
 
 	tflog.Debug(ctx, "Getting ISO with enriched properties", map[string]any{"iso_id": isoID})
 	iso, _, err = r.client.ISOs.Get(ctx, isoID)

--- a/internal/provider/resource_xelon_iso_test.go
+++ b/internal/provider/resource_xelon_iso_test.go
@@ -1,0 +1,182 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/Xelon-AG/xelon-sdk-go/xelon"
+)
+
+func init() {
+	resource.AddTestSweepers("xelon_iso", &resource.Sweeper{
+		Name: "xelon_iso",
+		F:    testSweepISOs,
+	})
+}
+
+func testSweepISOs(region string) error {
+	ctx := context.Background()
+	client, err := sharedClient(region)
+	if err != nil {
+		return err
+	}
+
+	isos, _, err := client.ISOs.List(ctx, &xelon.ISOListOptions{ListOptions: xelon.ListOptions{PerPage: 100}})
+	if err != nil {
+		return fmt.Errorf("getting ISO list: %s", err)
+	}
+
+	for _, iso := range isos {
+		if strings.HasPrefix(iso.Name, accTestPrefix) {
+			slog.Info("Deleting xelon_iso", "name", iso.Name, "id", iso.ID)
+			_, err := client.ISOs.Delete(ctx, iso.ID)
+			if err != nil {
+				slog.Warn("Error deleting ISO during sweep", "name", iso.Name, "error", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func TestAccResourceXelonISO(t *testing.T) {
+	isoName := fmt.Sprintf("%s-%s", accTestPrefix, acctest.RandString(10))
+	isoDescription := fmt.Sprintf("%s-description", accTestPrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// create and read
+			{
+				Config: testAccResourceXelonISOConfig(isoName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"xelon_iso.test",
+						tfjsonpath.New("active"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_iso.test",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact(""),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_iso.test",
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+			// update and read
+			{
+				Config: testAccResourceXelonISOConfigWithDescription(isoName, isoDescription),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"xelon_iso.test",
+						tfjsonpath.New("active"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_iso.test",
+						tfjsonpath.New("description"),
+						knownvalue.StringExact(isoDescription),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_iso.test",
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+		},
+	})
+}
+
+func TestAccResourceXelonISO_expectError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceXelonISOConfigWithoutName,
+				ExpectError: regexp.MustCompile(`The argument "name" is required`),
+			},
+			{
+				Config:      testAccResourceXelonISOConfigWithoutCategoryID,
+				ExpectError: regexp.MustCompile(`The argument "category_id" is required`),
+			},
+			{
+				Config:      testAccResourceXelonISOConfigWithoutURL,
+				ExpectError: regexp.MustCompile(`The argument "url" is required`),
+			},
+		},
+	})
+}
+
+func testAccResourceXelonISOConfig(name string) string {
+	return fmt.Sprintf(`
+resource "xelon_iso" "test" {
+  category_id = 2
+  cloud_id    = data.xelon_cloud.test.id
+  name        = %[1]q
+  url         = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.2.0-amd64-netinst.iso"
+}
+
+data "xelon_cloud" "test" {
+  # cloud id from test environment, change if updated
+  id = "c9ab2f0fcfde"
+}
+`, name)
+}
+
+func testAccResourceXelonISOConfigWithDescription(name, description string) string {
+	return fmt.Sprintf(`
+resource "xelon_iso" "test" {
+  category_id = 2
+  cloud_id    = data.xelon_cloud.test.id
+  description = %[2]q
+  name        = %[1]q
+  url         = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.2.0-amd64-netinst.iso"
+}
+
+data "xelon_cloud" "test" {
+  # cloud id from test environment, change if updated
+  id = "c9ab2f0fcfde"
+}
+`, name, description)
+}
+
+const testAccResourceXelonISOConfigWithoutName = `
+resource "xelon_iso" "test" {
+  category_id = 2
+  cloud_id    = "random-id"
+  url         = "random-url"
+}
+`
+
+const testAccResourceXelonISOConfigWithoutCategoryID = `
+resource "xelon_iso" "test" {
+  cloud_id = "random-id"
+  name     = "random-name"
+  url      = "random-url"
+}
+`
+
+const testAccResourceXelonISOConfigWithoutURL = `
+resource "xelon_iso" "test" {
+  category_id = 2
+  cloud_id    = "random-id"
+  name        = "random-name"
+}
+`


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes the issue with waiting for ready ISO after creation. xelon-sdk-go now returns `status` field (bool) that indicates whether ISO is in creating status or ready to use.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
