### PR TITLE
feat(resource/xelon_device): add user_data field for cloud-init support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+<a name="v1.2.0"></a>
+## v1.2.0 (2026-03-12)
+### Features
+* **resource/xelon_device**: add user_data field for cloud-init support
+
 <a name="v1.1.0"></a>
 ## v1.1.0 (2026-01-19)
 ### Bug Fixes

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -59,6 +59,7 @@ resource "xelon_device" "server" {
 - `script_id` (String) The ID of the script to be executed during the device setup.
 - `send_email` (Boolean) Whether to send an email notification upon successful device creation.
 - `ssh_key_id` (String) The ID of the SSH key to be used for authentication.
+- `user_data` (String) User data to provide when launching the device. Updates to this field will force a new resource to be created.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Xelon-AG/terraform-provider-xelon
 go 1.25
 
 require (
-	github.com/Xelon-AG/xelon-sdk-go v1.2.0
+	github.com/Xelon-AG/xelon-sdk-go v1.3.1
 	github.com/hashicorp/terraform-plugin-framework v1.17.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Xelon-AG/xelon-sdk-go v1.2.0 h1:N0ir8k7U+XDvYPFKQX2vkmjZskEA7vPP5i823NSshAY=
-github.com/Xelon-AG/xelon-sdk-go v1.2.0/go.mod h1:w+Wn4vz22E5nSxWxdRhZLeJEqhWn98Pt5krH3WF6AkA=
+github.com/Xelon-AG/xelon-sdk-go v1.3.1 h1:UP0Zz0hsWU2tPHFVv0PDE3J3QrgwxfvahAe5dtPjM4Y=
+github.com/Xelon-AG/xelon-sdk-go v1.3.1/go.mod h1:w+Wn4vz22E5nSxWxdRhZLeJEqhWn98Pt5krH3WF6AkA=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/provider/data_source_xelon_template.go
+++ b/internal/provider/data_source_xelon_template.go
@@ -148,7 +148,7 @@ func (d *templateDataSource) Read(ctx context.Context, request datasource.ReadRe
 		tflog.Info(ctx, "Searching for template by name", map[string]any{"template_name": templateName})
 
 		tflog.Debug(ctx, "Getting templates", map[string]any{"template_name": templateName})
-		templates, _, err := d.client.Templates.List(ctx, &xelon.TenantListOptions{Search: templateName})
+		templates, _, err := d.client.Templates.List(ctx, &xelon.TemplateListOptions{Search: templateName})
 		if err != nil {
 			response.Diagnostics.AddError("Unable to search template by name", err.Error())
 			return

--- a/internal/provider/resource_xelon_device.go
+++ b/internal/provider/resource_xelon_device.go
@@ -47,6 +47,7 @@ type deviceResourceModel struct {
 	SwapDiskSize     types.Int64                  `tfsdk:"swap_disk_size"`
 	TemplateID       types.String                 `tfsdk:"template_id"`
 	TenantID         types.String                 `tfsdk:"tenant_id"`
+	UserData         types.String                 `tfsdk:"user_data"`
 }
 
 type deviceNetworkResourceModel struct {
@@ -180,6 +181,13 @@ Devices are the virtual machines that run your applications.
 				MarkdownDescription: "The tenant ID to whom the device belongs.",
 				Required:            true,
 			},
+			"user_data": schema.StringAttribute{
+				MarkdownDescription: "User data to provide when launching the device. Updates to this field will force a new resource to be created.",
+				Optional:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 		},
 	}
 }
@@ -237,6 +245,11 @@ func (r *deviceResource) Create(ctx context.Context, request resource.CreateRequ
 		SwapDiskSize:         int(data.SwapDiskSize.ValueInt64()),
 		TemplateID:           data.TemplateID.ValueString(),
 		TenantID:             data.TenantID.ValueString(),
+	}
+	if data.UserData.ValueString() != "" {
+		createRequest.CloudInit = &xelon.DeviceCloudInit{
+			UserData: data.UserData.ValueString(),
+		}
 	}
 	tflog.Debug(ctx, "Creating device", map[string]any{"payload": createRequest})
 	createdDevice, _, err := r.client.Devices.Create(ctx, createRequest)


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PRs add a support for cloud-init (or ignite for RHEL) as `user_data` field. The type is depends on template.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
