### PR TITLE
chore: don't use blocks for release announcements in Slack

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -4,20 +4,13 @@ announce:
   slack:
     enabled: true
     channel: "#vdc_docker"
-    blocks:
-      - type: header
-        text:
-          type: plain_text
-          text: ":tada: New Release: Terraform Provider Xelon {{ .Tag }}"
-      - type: section
-        text:
-          type: mrkdwn
-          text: "{{ .ReleaseURL }}"
-      - type: divider
-      - type: section
-        text:
-          type: mrkdwn
-          text: "{{ .ReleaseNotes }}"
+    icon_emoji: ':rocket:'
+    message_template: |
+      :rocket: *Terraform Provider Xelon {{ .Tag }}* has been released!
+
+      {{ .ReleaseNotes }}
+
+      <{{ .ReleaseURL }}|View Release on GitHub>
 
 archives:
   - files:


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes failed Slack announcements (\n in blocks).

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
