### PR TITLE
fix(resource/xelon_device): deprecate enable_monitoring attribute

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -55,7 +55,7 @@ resource "xelon_device" "server" {
 ### Optional
 
 - `backup_job_id` (Number) The ID for the backup job.
-- `enable_monitoring` (Boolean) Whether to enable monitoring for the device.
+- `enable_monitoring` (Boolean, Deprecated) Whether to enable monitoring for the device.
 - `script_id` (String) The ID of the script to be executed during the device setup.
 - `send_email` (Boolean) Whether to send an email notification upon successful device creation.
 - `ssh_key_id` (String) The ID of the SSH key to be used for authentication.

--- a/internal/provider/data_source_xelon_iso_test.go
+++ b/internal/provider/data_source_xelon_iso_test.go
@@ -66,7 +66,7 @@ resource "xelon_iso" "test" {
   category_id = 2
   cloud_id    = data.xelon_cloud.test.id
   name = %[1]q
-  url  = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.3.0-amd64-netinst.iso"
+  url  = "https://cdimage.debian.org/releases/20.04.6/ubuntu-20.04.6-live-server-amd64.iso"
 }
 
 data "xelon_cloud" "test" {

--- a/internal/provider/resource_xelon_device.go
+++ b/internal/provider/resource_xelon_device.go
@@ -94,6 +94,7 @@ Devices are the virtual machines that run your applications.
 				Required:            true,
 			},
 			"enable_monitoring": schema.BoolAttribute{
+				DeprecationMessage:  "enable_monitoring is deprecated and will not be supported in a future release.",
 				MarkdownDescription: "Whether to enable monitoring for the device.",
 				Optional:            true,
 				Computed:            true,
@@ -288,7 +289,6 @@ func (r *deviceResource) Create(ctx context.Context, request resource.CreateRequ
 	// map response body to attributes
 	data.CPUCoreCount = types.Int64Value(int64(device.CPUCores))
 	data.DisplayName = types.StringValue(device.DisplayName)
-	data.EnableMonitoring = types.BoolValue(device.MonitoringEnabled)
 	data.Hostname = types.StringValue(device.HostName)
 	data.ID = types.StringValue(device.ID)
 	data.Memory = types.Int64Value(int64(device.RAM))
@@ -324,7 +324,6 @@ func (r *deviceResource) Read(ctx context.Context, request resource.ReadRequest,
 	// map response body to attributes
 	data.CPUCoreCount = types.Int64Value(int64(device.CPUCores))
 	data.DisplayName = types.StringValue(device.DisplayName)
-	data.EnableMonitoring = types.BoolValue(device.MonitoringEnabled)
 	data.Hostname = types.StringValue(device.HostName)
 	data.ID = types.StringValue(device.ID)
 	data.Memory = types.Int64Value(int64(device.RAM))

--- a/internal/provider/resource_xelon_iso_test.go
+++ b/internal/provider/resource_xelon_iso_test.go
@@ -130,7 +130,7 @@ resource "xelon_iso" "test" {
   category_id = 2
   cloud_id    = data.xelon_cloud.test.id
   name        = %[1]q
-  url         = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.3.0-amd64-netinst.iso"
+  url         = "https://cdimage.debian.org/releases/20.04.6/ubuntu-20.04.6-live-server-amd64.iso"
 }
 
 data "xelon_cloud" "test" {
@@ -147,7 +147,7 @@ resource "xelon_iso" "test" {
   cloud_id    = data.xelon_cloud.test.id
   description = %[2]q
   name        = %[1]q
-  url         = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.3.0-amd64-netinst.iso"
+  url         = "https://cdimage.debian.org/releases/20.04.6/ubuntu-20.04.6-live-server-amd64.iso"
 }
 
 data "xelon_cloud" "test" {


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes the issue with deprecated `enable_monitoring` attribute on server side. The attribute will be removed in 1.4.0+ versions.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
--->
Closes #52 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
