### PR TITLE
chore(slack): fix issue with invalid characters in blocks

### DIFF
--- a/.github/changelog/CHANGELOG.tpl.md
+++ b/.github/changelog/CHANGELOG.tpl.md
@@ -1,6 +1,5 @@
 {{ if .Versions -}}
 {{ if .Unreleased.CommitGroups -}}
-<a name="unreleased"></a>
 ## [Unreleased]
 {{ range .Unreleased.CommitGroups -}}
 ### {{ .Title }}
@@ -20,7 +19,6 @@
 {{ end -}}
 
 {{ range .Versions }}
-<a name="{{ .Tag.Name }}"></a>
 ## {{ .Tag.Name }} ({{ datetime "2006-01-02" .Tag.Date }})
 {{ range .CommitGroups -}}
 ### {{ .Title }}

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -5,12 +5,21 @@ announce:
     enabled: true
     channel: "#vdc_docker"
     icon_emoji: ':rocket:'
-    message_template: |
-      :rocket: *Terraform Provider Xelon {{ .Tag }}* has been released!
-
-      {{ .ReleaseNotes }}
-
-      <{{ .ReleaseURL }}|View Release on GitHub>
+    blocks:
+      - type: header
+        text:
+          type: plain_text
+          text: ":tada: New Release: Terraform Provider Xelon {{ .Tag }}"
+      - type: section
+        text:
+          type: mrkdwn
+          text: "{{ .ReleaseURL }}"
+      - type: divider
+      - type: section
+        text:
+          type: mrkdwn
+          text: |
+            {{ .ReleaseNotes }}
 
 archives:
   - files:


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes the issue with failed Slack announcement and using `blocks`. The reason was having this line `<a name="v{{Tag}}"></a>`. Goreleaser doesn't like `"v`.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
