### PR TITLE
fix(resource/xelon_device): make attributes required depending on user_data

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -47,8 +47,6 @@ resource "xelon_device" "server" {
 - `hostname` (String) The hostname of the device.
 - `memory` (Number) The amount of RAM in GB to allocate to the device.
 - `networks` (Attributes Set) The networks configured for the device. (see [below for nested schema](#nestedatt--networks))
-- `password` (String, Sensitive) The password for the device root or administrator user.
-- `swap_disk_size` (Number) The size of the swap disk in GB.
 - `template_id` (String) The template ID used to create the device.
 - `tenant_id` (String) The tenant ID to whom the device belongs.
 
@@ -58,9 +56,11 @@ resource "xelon_device" "server" {
 - `cpu_core_hotplug` (Boolean) If `true`, enables CPU core hot‑plug functionality for the device. It allows dynamically adding or removing CPU cores without powering off the device.
 - `enable_monitoring` (Boolean, Deprecated) Whether to enable monitoring for the device.
 - `memory_hotplug` (Boolean) If `true`, enables memory hot‑plug functionality for the device. It allows dynamically increasing or decreasing the amount of RAM without powering off the device.
+- `password` (String, Sensitive) The password for the device root or administrator user. Required if `user_data` is empty.
 - `script_id` (String) The ID of the script to be executed during the device setup.
 - `send_email` (Boolean) Whether to send an email notification upon successful device creation.
 - `ssh_key_id` (String) The ID of the SSH key to be used for authentication.
+- `swap_disk_size` (Number) The size of the swap disk in GB. Required if `user_data` is empty.
 - `user_data` (String) User data to provide when launching the device. Updates to this field will force a new resource to be created.
 
 ### Read-Only
@@ -74,10 +74,10 @@ resource "xelon_device" "server" {
 
 Required:
 
-- `connected` (Boolean) Whether the network should automatically connect when the device powers on.
 - `id` (String) The network ID to which the device will connect.
 
 Optional:
 
+- `connected` (Boolean) Whether the network should automatically connect when the device powers on.
 - `ipv4_address` (String) The static IP address for the network connection.
 - `ipv4_address_id` (String) The ID of the static IP address for the network connection.

--- a/internal/provider/helper/requires_valid_user_data.go
+++ b/internal/provider/helper/requires_valid_user_data.go
@@ -1,0 +1,69 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = (*requiresValidUserData)(nil)
+
+type requiresValidUserData struct {
+	requiredExpressions path.Expressions
+}
+
+func (av requiresValidUserData) Description(ctx context.Context) string {
+	return av.MarkdownDescription(ctx)
+}
+
+func (av requiresValidUserData) MarkdownDescription(_ context.Context) string {
+	return "Ensures that if user_data is not set, all required attributes configured."
+}
+
+func (av requiresValidUserData) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if !request.ConfigValue.IsNull() && !request.ConfigValue.IsUnknown() {
+		// skip validation if user_data is defined
+		return
+	}
+
+	expressions := request.PathExpression.MergeExpressions(av.requiredExpressions...)
+
+	for _, expression := range expressions {
+		matchedPaths, diags := request.Config.PathMatches(ctx, expression)
+		response.Diagnostics.Append(diags...)
+		// collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, matchedPath := range matchedPaths {
+			var matchedPathValue attr.Value
+			diags := request.Config.GetAttribute(ctx, matchedPath, &matchedPathValue)
+			response.Diagnostics.Append(diags...)
+			// collect all errors
+			if diags.HasError() {
+				continue
+			}
+			// delay validation until all involved attribute have a known value
+			if matchedPathValue.IsUnknown() {
+				return
+			}
+			if matchedPathValue.IsNull() {
+				response.Diagnostics.AddAttributeError(
+					request.Path,
+					"Missing required attribute",
+					fmt.Sprintf("Attribute %q must be specified when %q is not set.", matchedPath, "user_data"),
+				)
+			}
+		}
+	}
+}
+
+func RequiresValidUserData(expressions ...path.Expression) validator.String {
+	return &requiresValidUserData{
+		requiredExpressions: expressions,
+	}
+}

--- a/internal/provider/resource_xelon_device.go
+++ b/internal/provider/resource_xelon_device.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -157,7 +158,10 @@ Devices are the virtual machines that run your applications.
 					Attributes: map[string]schema.Attribute{
 						"connected": schema.BoolAttribute{
 							MarkdownDescription: "Whether the network should automatically connect when the device powers on.",
-							Required:            true,
+							Optional:            true,
+							PlanModifiers: []planmodifier.Bool{
+								boolplanmodifier.UseStateForUnknown(),
+							},
 						},
 						"id": schema.StringAttribute{
 							MarkdownDescription: "The network ID to which the device will connect.",
@@ -176,9 +180,12 @@ Devices are the virtual machines that run your applications.
 				Required: true,
 			},
 			"password": schema.StringAttribute{
-				MarkdownDescription: "The password for the device root or administrator user.",
-				Required:            true,
+				MarkdownDescription: "The password for the device root or administrator user. Required if `user_data` is empty.",
+				Optional:            true,
 				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"send_email": schema.BoolAttribute{
 				MarkdownDescription: "Whether to send an email notification upon successful device creation.",
@@ -209,9 +216,10 @@ Devices are the virtual machines that run your applications.
 				},
 			},
 			"swap_disk_size": schema.Int64Attribute{
-				MarkdownDescription: "The size of the swap disk in GB.",
-				Required:            true,
+				MarkdownDescription: "The size of the swap disk in GB. Required if `user_data` is empty.",
+				Optional:            true,
 				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
 					helper.ExpandOnlyStorageSizeModifier(),
 				},
 			},
@@ -231,6 +239,13 @@ Devices are the virtual machines that run your applications.
 				Optional:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					helper.RequiresValidUserData(path.Expressions{
+						path.MatchRoot("password"),
+						path.MatchRoot("swap_disk_size"),
+					}...,
+					),
 				},
 			},
 		},


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR make `xelon_device` attributes optional or required depends on `user_data`. When `user_data` is set, password and swap_disk_size will be optional.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
