### PR TITLE
chore(release): remove ReleaseNotes slack block because of escaping issues

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -10,16 +10,11 @@ announce:
         text:
           type: plain_text
           text: ":tada: New Release: Terraform Provider Xelon {{ .Tag }}"
-      - type: section
-        text:
-          type: mrkdwn
-          text: "{{ .ReleaseURL }}"
       - type: divider
       - type: section
         text:
           type: mrkdwn
-          text: |
-            {{ .ReleaseNotes }}
+          text: "We've have just shipped a new version, bringing new features and important stability improvements. See the <{{ .ReleaseURL }}|release notes> for all the details."
 
 archives:
   - files:

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.1.6 h1:ZcV+Ropw6Qn0AX9brlQLAUXfqLBc7Bl+f/DmNxpLfdw=
 github.com/ProtonMail/go-crypto v1.1.6/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Xelon-AG/xelon-sdk-go v1.4.0 h1:VlaJWZVXLzK39YkUs/mpNOyeftGMRE8DKFTW6xt3jqs=
-github.com/Xelon-AG/xelon-sdk-go v1.4.0/go.mod h1:w+Wn4vz22E5nSxWxdRhZLeJEqhWn98Pt5krH3WF6AkA=
 github.com/Xelon-AG/xelon-sdk-go v1.5.0 h1:16ETTS7KynFXR2rbjFqWmIetIL9kJAXecNjMFL/y0E8=
 github.com/Xelon-AG/xelon-sdk-go v1.5.0/go.mod h1:w+Wn4vz22E5nSxWxdRhZLeJEqhWn98Pt5krH3WF6AkA=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
If `{{ .ReleaseNotes }}` contains line break, then Goreleaser is not able to properly escape it. Template function cannot be used as well :(.

This PR replace the releaseNotes block with the link to GH release.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
