### PR TITLE
fix(resource/xelon_device): use new state to track device in-flight operations

### DIFF
--- a/internal/provider/helper/device_status.go
+++ b/internal/provider/helper/device_status.go
@@ -17,9 +17,7 @@ const (
 	deviceStateProvisioning     = "provisioning"
 	deviceStateReadyForBasicUse = "readyForBasicUse"
 	deviceStateReady            = "ready"
-
-	deviceDiskProvisioning = "diskProvisioning"
-	deviceDiskUpdated      = "diskUpdated"
+	deviceStateUpdating         = "updating"
 
 	deviceDiskSnapshotsExist   = "snapshotsExist"
 	deviceDiskSnapshotsMissing = "snapshotsMissing"
@@ -68,30 +66,13 @@ func statusDeviceState(ctx context.Context, client *xelon.Client, deviceID strin
 			deviceState = deviceStateReady
 		case 2:
 			deviceState = deviceStateReadyForBasicUse
+		case 3:
+			deviceState = deviceStateUpdating
 		default:
 			return nil, "", fmt.Errorf("failed to get correct device state: %d", device.State)
 		}
 
 		return device, deviceState, nil
-	}
-}
-
-func statusDeviceDiskUpdated(ctx context.Context, client *xelon.Client, deviceID, diskID string, expectedDiskSize int) retry.StateRefreshFunc {
-	return func() (any, string, error) {
-		device, _, err := client.Devices.Get(ctx, deviceID)
-		if err != nil {
-			return nil, "", err
-		}
-		if device == nil {
-			return nil, "", fmt.Errorf("failed to get device with id: %s", deviceID)
-		}
-
-		for _, storage := range device.Storages {
-			if storage.ID == diskID && storage.Size == expectedDiskSize {
-				return device, deviceDiskUpdated, nil
-			}
-		}
-		return device, deviceDiskProvisioning, nil
 	}
 }
 

--- a/internal/provider/helper/device_wait.go
+++ b/internal/provider/helper/device_wait.go
@@ -44,7 +44,7 @@ func WaitDevicePowerStateOff(ctx context.Context, client *xelon.Client, deviceID
 
 func WaitDeviceStateReady(ctx context.Context, client *xelon.Client, deviceID string) error {
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{deviceStateProvisioning, deviceStateReadyForBasicUse},
+		Pending:    []string{deviceStateProvisioning, deviceStateReadyForBasicUse, deviceStateUpdating},
 		Target:     []string{deviceStateReady},
 		Timeout:    10 * time.Minute,
 		MinTimeout: 5 * time.Second,
@@ -54,22 +54,6 @@ func WaitDeviceStateReady(ctx context.Context, client *xelon.Client, deviceID st
 
 	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
 		return fmt.Errorf("failed to wait for device (%s) to become ready: %w", deviceID, err)
-	}
-	return nil
-}
-
-func WaitDeviceDiskSizeUpdated(ctx context.Context, client *xelon.Client, deviceID, diskID string, expectedDiskSize int) error {
-	stateConf := &retry.StateChangeConf{
-		Pending:    []string{deviceDiskProvisioning},
-		Target:     []string{deviceDiskUpdated},
-		Timeout:    10 * time.Minute,
-		MinTimeout: 5 * time.Second,
-		Delay:      3 * time.Second,
-		Refresh:    statusDeviceDiskUpdated(ctx, client, deviceID, diskID, expectedDiskSize),
-	}
-
-	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
-		return fmt.Errorf("failed to wait for device disk (%s) to become updated: %w", diskID, err)
 	}
 	return nil
 }

--- a/internal/provider/resource_xelon_device.go
+++ b/internal/provider/resource_xelon_device.go
@@ -470,7 +470,7 @@ func (r *deviceResource) Update(ctx context.Context, request resource.UpdateRequ
 		tflog.Debug(ctx, "Updated disk size", map[string]any{"device_id": deviceID, "data": device})
 
 		tflog.Info(ctx, "Waiting for disk size to be updated after extension")
-		err = helper.WaitDeviceDiskSizeUpdated(ctx, r.client, deviceID, diskID, newDiskSize)
+		err = helper.WaitDeviceStateReady(ctx, r.client, deviceID)
 		if err != nil {
 			response.Diagnostics.AddError("Unable to wait for disk size to be updated", err.Error())
 			return
@@ -502,7 +502,7 @@ func (r *deviceResource) Update(ctx context.Context, request resource.UpdateRequ
 		tflog.Debug(ctx, "Updated swap disk size", map[string]any{"device_id": deviceID, "data": device})
 
 		tflog.Info(ctx, "Waiting for swap disk size to be updated after extension")
-		err = helper.WaitDeviceDiskSizeUpdated(ctx, r.client, deviceID, swapDiskID, newSwapDiskSize)
+		err = helper.WaitDeviceStateReady(ctx, r.client, deviceID)
 		if err != nil {
 			response.Diagnostics.AddError("Unable to wait for swap disk size to be updated", err.Error())
 			return
@@ -573,6 +573,15 @@ func (r *deviceResource) Update(ctx context.Context, request resource.UpdateRequ
 				}
 			}
 		}
+
+		// ensure device is in ready state
+		tflog.Info(ctx, "Waiting for device to be ready", map[string]any{"device_id": deviceID})
+		err = helper.WaitDeviceStateReady(ctx, r.client, deviceID)
+		if err != nil {
+			response.Diagnostics.AddError("Unable to wait for device to be ready", err.Error())
+			return
+		}
+		tflog.Info(ctx, "Device is ready", map[string]any{"device_id": deviceID})
 
 		tflog.Debug(ctx, "Getting device with enriched data", map[string]any{"device_id": deviceID})
 		device, _, err := r.client.Devices.Get(ctx, deviceID)


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR utilizes new `state=3` from backend API to track in-flight operations.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
