### PR TITLE
fix(resource/xelon_device): failed update for password field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/Xelon-AG/xelon-sdk-go v1.12.0
+	github.com/Xelon-AG/xelon-sdk-go v1.13.1
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Xelon-AG/xelon-sdk-go v1.12.0 h1:fUT5BshgdLjApYCcvXRo39rPMMWhcXwaQRbH0C0hEPM=
-github.com/Xelon-AG/xelon-sdk-go v1.12.0/go.mod h1:lkPHoPVkE0qCOvFO9phF4l8dBglxrrxyKlfAG3/VGBE=
+github.com/Xelon-AG/xelon-sdk-go v1.13.1 h1:9/S1Mgi2+2JDFGT0Fg1/nbagOwetSLYd30235IOfGFo=
+github.com/Xelon-AG/xelon-sdk-go v1.13.1/go.mod h1:lkPHoPVkE0qCOvFO9phF4l8dBglxrrxyKlfAG3/VGBE=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/provider/data_source_xelon_iso_test.go
+++ b/internal/provider/data_source_xelon_iso_test.go
@@ -63,10 +63,10 @@ data "xelon_iso" "test" {
 }
 
 resource "xelon_iso" "test" {
-  category_id = 2
+  category_id = 7
   cloud_id    = data.xelon_cloud.test.id
   name = %[1]q
-  url  = "https://cdimage.debian.org/releases/20.04.6/ubuntu-20.04.6-live-server-amd64.iso"
+  url  = "http://tinycorelinux.net/16.x/x86_64/release/TinyCorePure64-current.iso"
 }
 
 data "xelon_cloud" "test" {

--- a/internal/provider/resource_xelon_device.go
+++ b/internal/provider/resource_xelon_device.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
@@ -25,6 +24,7 @@ var (
 	_ resource.Resource                = (*deviceResource)(nil)
 	_ resource.ResourceWithConfigure   = (*deviceResource)(nil)
 	_ resource.ResourceWithImportState = (*deviceResource)(nil)
+	_ resource.ResourceWithModifyPlan  = (*deviceResource)(nil)
 )
 
 // deviceResource is the device resource implementation.
@@ -184,7 +184,7 @@ Devices are the virtual machines that run your applications.
 				Optional:            true,
 				Sensitive:           true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 			"send_email": schema.BoolAttribute{
@@ -239,13 +239,6 @@ Devices are the virtual machines that run your applications.
 				Optional:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
-				},
-				Validators: []validator.String{
-					helper.RequiresValidUserData(path.Expressions{
-						path.MatchRoot("password"),
-						path.MatchRoot("swap_disk_size"),
-					}...,
-					),
 				},
 			},
 		},
@@ -317,7 +310,12 @@ func (r *deviceResource) Create(ctx context.Context, request resource.CreateRequ
 	if data.MemoryHotPlug.ValueBool() {
 		createRequest.EnableRAMHotAdd = data.MemoryHotPlug.ValueBool()
 	}
-	tflog.Debug(ctx, "Creating device", map[string]any{"payload": createRequest})
+	tflog.Debug(ctx, "Creating device", map[string]any{
+		"display_name": data.DisplayName.ValueString(),
+		"hostname":     data.Hostname.ValueString(),
+		"template_id":  data.TemplateID.ValueString(),
+		"tenant_id":    data.TenantID.ValueString(),
+	})
 	createdDevice, _, err := r.client.Devices.Create(ctx, createRequest)
 	if err != nil {
 		response.Diagnostics.AddError("Unable to create device", err.Error())
@@ -647,6 +645,56 @@ func (r *deviceResource) Delete(ctx context.Context, request resource.DeleteRequ
 
 func (r *deviceResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), request, response)
+}
+
+func (r *deviceResource) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
+	if request.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan deviceResourceModel
+	diags := request.Plan.Get(ctx, &plan)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	requiresCreateInputs := request.State.Raw.IsNull()
+	if !request.State.Raw.IsNull() {
+		var state deviceResourceModel
+		response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		requiresCreateInputs = !plan.Password.Equal(state.Password) ||
+			!plan.TemplateID.Equal(state.TemplateID) ||
+			!plan.UserData.Equal(state.UserData)
+	}
+	if !requiresCreateInputs {
+		return
+	}
+
+	if plan.UserData.IsUnknown() || plan.UserData.ValueString() != "" {
+		return
+	}
+	if plan.Password.IsUnknown() || plan.SwapDiskSize.IsUnknown() {
+		return
+	}
+	if plan.Password.ValueString() == "" {
+		response.Diagnostics.AddAttributeError(
+			path.Root("password"),
+			"Missing password or user_data",
+			`Either "password" or "user_data" must be specified when creating or replacing a device.`,
+		)
+	}
+	if plan.SwapDiskSize.IsNull() {
+		response.Diagnostics.AddAttributeError(
+			path.Root("swap_disk_size"),
+			"Missing required attribute",
+			`Attribute "swap_disk_size" must be specified when "user_data" is not set.`,
+		)
+	}
 }
 
 // findDiskIDBySize looks up for xelon.DeviceStorage by size. If multiple disks are found,

--- a/internal/provider/resource_xelon_device_acc_test.go
+++ b/internal/provider/resource_xelon_device_acc_test.go
@@ -1,0 +1,212 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+
+	"github.com/Xelon-AG/xelon-sdk-go/xelon"
+)
+
+func init() {
+	resource.AddTestSweepers("xelon_device", &resource.Sweeper{
+		Name: "xelon_device",
+		F: func(region string) error {
+			ctx := context.Background()
+			client, err := sharedClient(region)
+			if err != nil {
+				return err
+			}
+
+			devices, errf := client.Devices.All(ctx, &xelon.ListOptions{PerPage: 100})
+			for device := range devices {
+				if strings.HasPrefix(device.DisplayName, accTestPrefix) {
+					slog.Info("Deleting xelon_device", "name", device.DisplayName, "id", device.ID)
+					_, err := client.Devices.Delete(ctx, device.ID)
+					if err != nil {
+						slog.Warn("Error deleting device during sweep", "name", device.DisplayName, "error", err)
+					}
+				}
+			}
+			if err := errf(); err != nil {
+				return fmt.Errorf("getting device list: %w", err)
+			}
+
+			return nil
+		},
+	})
+}
+
+func TestAccResourceXelonDevice(t *testing.T) {
+	hostname := fmt.Sprintf("%s-%s", accTestPrefix, acctest.RandString(10))
+	displayName := hostname
+	displayNameUpdated := fmt.Sprintf("%s-%s", accTestPrefix, acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// create and read
+			{
+				Config: testAccResourceXelonDeviceConfig(displayName, hostname, 10),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("cpu_core_count"),
+						knownvalue.Int64Exact(2),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("disk_id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("disk_size"),
+						knownvalue.Int64Exact(10),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("display_name"),
+						knownvalue.StringExact(displayName),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("enable_monitoring"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("hostname"),
+						knownvalue.StringExact(hostname),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("memory"),
+						knownvalue.Int64Exact(2),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("swap_disk_id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("swap_disk_size"),
+						knownvalue.Int64Exact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("tenant_id"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+			// update and read
+			{
+				Config: testAccResourceXelonDeviceConfig(displayNameUpdated, hostname, 15),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("cpu_core_count"),
+						knownvalue.Int64Exact(2),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("disk_id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("disk_size"),
+						knownvalue.Int64Exact(15),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("display_name"),
+						knownvalue.StringExact(displayNameUpdated),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("enable_monitoring"),
+						knownvalue.Bool(false),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("hostname"),
+						knownvalue.StringExact(hostname),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("memory"),
+						knownvalue.Int64Exact(2),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("swap_disk_id"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("swap_disk_size"),
+						knownvalue.Int64Exact(1),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_device.test",
+						tfjsonpath.New("tenant_id"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccResourceXelonDeviceConfig(displayName, hostname string, diskSize int) string {
+	return fmt.Sprintf(`
+resource "xelon_device" "test" {
+  cpu_core_count = 2
+  disk_size      = %[3]d
+  display_name   = %[1]q
+  hostname       = %[2]q
+  memory         = 2
+  password       = "J78q3H"
+  swap_disk_size = 1
+  template_id    = data.xelon_template.test.id
+  tenant_id      = data.xelon_tenant.test.id
+
+  networks = [
+    {
+      connected = true
+      id        = "654871d16146"
+    }
+  ]
+}
+
+data "xelon_tenant" "test" {}
+
+data "xelon_template" "test" {
+  cloud_id    = "e96db9d92ec7"
+  name        = "Debian 11"
+  most_recent = true
+}
+`, displayName, hostname, diskSize)
+}

--- a/internal/provider/resource_xelon_device_test.go
+++ b/internal/provider/resource_xelon_device_test.go
@@ -2,211 +2,203 @@ package provider
 
 import (
 	"context"
-	"fmt"
-	"log/slog"
-	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
-	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-
-	"github.com/Xelon-AG/xelon-sdk-go/xelon"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func init() {
-	resource.AddTestSweepers("xelon_device", &resource.Sweeper{
-		Name: "xelon_device",
-		F: func(region string) error {
-			ctx := context.Background()
-			client, err := sharedClient(region)
-			if err != nil {
-				return err
-			}
+func TestResourceXelonDevice_Schema_Password(t *testing.T) {
+	deviceSchema := testDeviceResourceSchema(t)
 
-			devices, errf := client.Devices.All(ctx, &xelon.ListOptions{PerPage: 100})
-			for device := range devices {
-				if strings.HasPrefix(device.DisplayName, accTestPrefix) {
-					slog.Info("Deleting xelon_device", "name", device.DisplayName, "id", device.ID)
-					_, err := client.Devices.Delete(ctx, device.ID)
-					if err != nil {
-						slog.Warn("Error deleting device during sweep", "name", device.DisplayName, "error", err)
-					}
-				}
-			}
-			if err := errf(); err != nil {
-				return fmt.Errorf("getting device list: %w", err)
-			}
+	password, ok := deviceSchema.Attributes["password"].(schema.StringAttribute)
+	require.True(t, ok)
 
-			return nil
-		},
-	})
+	assert.True(t, password.Optional)
+	assert.False(t, password.Computed)
+	assert.True(t, password.Sensitive)
+	require.Len(t, password.PlanModifiers, 1)
+	assert.Contains(t, password.PlanModifiers[0].Description(context.Background()), "configured and changes")
 }
 
-func TestAccResourceXelonDevice(t *testing.T) {
-	hostname := fmt.Sprintf("%s-%s", accTestPrefix, acctest.RandString(10))
-	displayName := hostname
-	displayNameUpdated := fmt.Sprintf("%s-%s", accTestPrefix, acctest.RandString(10))
+func TestResourceXelonDevice_Create_RequiresPasswordOrUserData(t *testing.T) {
+	ctx := context.Background()
+	deviceSchema := testDeviceResourceSchema(t)
+	plan := testDeviceResourcePlan(t, ctx, deviceSchema, types.StringNull(), types.StringNull())
+	state := tfsdk.State{
+		Schema: deviceSchema,
+		Raw:    tftypes.NewValue(deviceSchema.Type().TerraformType(ctx), nil),
+	}
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// create and read
+	response := &resource.ModifyPlanResponse{}
+	NewDeviceResource().(*deviceResource).ModifyPlan(ctx, resource.ModifyPlanRequest{
+		Plan:  plan,
+		State: state,
+	}, response)
+
+	require.True(t, response.Diagnostics.HasError())
+	assert.True(t, response.Diagnostics.Equal(expectedDeviceMissingPasswordOrUserDataDiagnostics()))
+}
+
+func TestResourceXelonDevice_Import_DoesNotRequirePasswordOrUserData(t *testing.T) {
+	ctx := context.Background()
+	deviceSchema := testDeviceResourceSchema(t)
+	plan := testDeviceResourcePlan(t, ctx, deviceSchema, types.StringNull(), types.StringNull())
+	state := tfsdk.State{
+		Schema: deviceSchema,
+		Raw:    plan.Raw,
+	}
+
+	response := &resource.ModifyPlanResponse{}
+	NewDeviceResource().(*deviceResource).ModifyPlan(ctx, resource.ModifyPlanRequest{
+		Plan:  plan,
+		State: state,
+	}, response)
+
+	assert.False(t, response.Diagnostics.HasError())
+}
+
+func TestResourceXelonDevice_Import_PasswordOmittedDoesNotRequireReplacement(t *testing.T) {
+	response := testDevicePasswordPlanModifierResponse(t, types.StringNull(), types.StringNull(), types.StringNull())
+
+	require.False(t, response.Diagnostics.HasError())
+	assert.False(t, response.RequiresReplace)
+}
+
+func TestResourceXelonDevice_Import_ConfiguredPasswordRequiresReplacement(t *testing.T) {
+	response := testDevicePasswordPlanModifierResponse(t, types.StringValue("new-password"), types.StringValue("new-password"), types.StringNull())
+
+	require.False(t, response.Diagnostics.HasError())
+	assert.True(t, response.RequiresReplace)
+}
+
+func TestResourceXelonDevice_Update_PasswordChangeRequiresReplacement(t *testing.T) {
+	response := testDevicePasswordPlanModifierResponse(t, types.StringValue("new-password"), types.StringValue("new-password"), types.StringValue("old-password"))
+
+	require.False(t, response.Diagnostics.HasError())
+	assert.True(t, response.RequiresReplace)
+}
+
+func TestResourceXelonDevice_Replacement_RequiresPasswordOrUserData(t *testing.T) {
+	ctx := context.Background()
+	deviceSchema := testDeviceResourceSchema(t)
+	plan := testDeviceResourcePlan(t, ctx, deviceSchema, types.StringNull(), types.StringNull())
+	statePlan := testDeviceResourcePlanWithTemplateID(t, ctx, deviceSchema, types.StringNull(), types.StringNull(), "old-template-id")
+	state := tfsdk.State{
+		Schema: deviceSchema,
+		Raw:    statePlan.Raw,
+	}
+
+	response := &resource.ModifyPlanResponse{}
+	NewDeviceResource().(*deviceResource).ModifyPlan(ctx, resource.ModifyPlanRequest{
+		Plan:  plan,
+		State: state,
+	}, response)
+
+	require.True(t, response.Diagnostics.HasError())
+	assert.True(t, response.Diagnostics.Equal(expectedDeviceMissingPasswordOrUserDataDiagnostics()))
+}
+
+func testDeviceResourceSchema(t *testing.T) schema.Schema {
+	t.Helper()
+
+	r := NewDeviceResource()
+	response := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, response)
+	require.False(t, response.Diagnostics.HasError())
+
+	return response.Schema
+}
+
+func testDeviceResourcePlan(t *testing.T, ctx context.Context, deviceSchema schema.Schema, password, userData types.String) tfsdk.Plan {
+	t.Helper()
+
+	return testDeviceResourcePlanWithTemplateID(t, ctx, deviceSchema, password, userData, "template-id")
+}
+
+func testDeviceResourcePlanWithTemplateID(t *testing.T, ctx context.Context, deviceSchema schema.Schema, password, userData types.String, templateID string) tfsdk.Plan {
+	t.Helper()
+
+	plan := tfsdk.Plan{Schema: deviceSchema}
+	diags := plan.Set(ctx, &deviceResourceModel{
+		BackupJobID:      types.Int64Null(),
+		CPUCoreCount:     types.Int64Value(2),
+		CPUCoreHotPlug:   types.BoolNull(),
+		DiskID:           types.StringUnknown(),
+		DiskSize:         types.Int64Value(10),
+		DisplayName:      types.StringValue("test-device"),
+		EnableMonitoring: types.BoolNull(),
+		Hostname:         types.StringValue("test-device"),
+		ID:               types.StringUnknown(),
+		Memory:           types.Int64Value(2),
+		MemoryHotPlug:    types.BoolNull(),
+		Networks: []deviceNetworkResourceModel{
 			{
-				Config: testAccResourceXelonDeviceConfig(displayName, hostname, 10),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("cpu_core_count"),
-						knownvalue.Int64Exact(2),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("disk_id"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("disk_size"),
-						knownvalue.Int64Exact(10),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("display_name"),
-						knownvalue.StringExact(displayName),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("enable_monitoring"),
-						knownvalue.Bool(false),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("hostname"),
-						knownvalue.StringExact(hostname),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("id"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("memory"),
-						knownvalue.Int64Exact(2),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("swap_disk_id"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("swap_disk_size"),
-						knownvalue.Int64Exact(1),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("tenant_id"),
-						knownvalue.NotNull(),
-					),
-				},
-			},
-			// update and read
-			{
-				Config: testAccResourceXelonDeviceConfig(displayNameUpdated, hostname, 15),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("cpu_core_count"),
-						knownvalue.Int64Exact(2),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("disk_id"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("disk_size"),
-						knownvalue.Int64Exact(15),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("display_name"),
-						knownvalue.StringExact(displayNameUpdated),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("enable_monitoring"),
-						knownvalue.Bool(false),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("hostname"),
-						knownvalue.StringExact(hostname),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("id"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("memory"),
-						knownvalue.Int64Exact(2),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("swap_disk_id"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("swap_disk_size"),
-						knownvalue.Int64Exact(1),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_device.test",
-						tfjsonpath.New("tenant_id"),
-						knownvalue.NotNull(),
-					),
-				},
+				Connected:   types.BoolValue(true),
+				ID:          types.StringValue("network-id"),
+				IPAddress:   types.StringNull(),
+				IPAddressID: types.StringNull(),
 			},
 		},
+		Password:     password,
+		SendEmail:    types.BoolNull(),
+		SSHKeyID:     types.StringNull(),
+		ScriptID:     types.StringNull(),
+		SwapDiskID:   types.StringUnknown(),
+		SwapDiskSize: types.Int64Value(1),
+		TemplateID:   types.StringValue(templateID),
+		TenantID:     types.StringValue("tenant-id"),
+		UserData:     userData,
 	})
+	require.False(t, diags.HasError())
+
+	return plan
 }
 
-func testAccResourceXelonDeviceConfig(displayName, hostname string, diskSize int) string {
-	return fmt.Sprintf(`
-resource "xelon_device" "test" {
-  cpu_core_count = 2
-  disk_size      = %[3]d
-  display_name   = %[1]q
-  hostname       = %[2]q
-  memory         = 2
-  password       = "J78q3H"
-  swap_disk_size = 1
-  template_id    = data.xelon_template.test.id
-  tenant_id      = data.xelon_tenant.test.id
+func testDevicePasswordPlanModifierResponse(t *testing.T, configValue, planValue, stateValue types.String) *planmodifier.StringResponse {
+	t.Helper()
 
-  networks = [
-    {
-      connected = true
-      id        = "654871d16146"
-    }
-  ]
+	ctx := context.Background()
+	deviceSchema := testDeviceResourceSchema(t)
+
+	password, ok := deviceSchema.Attributes["password"].(schema.StringAttribute)
+	require.True(t, ok)
+	require.Len(t, password.PlanModifiers, 1)
+
+	plan := testDeviceResourcePlan(t, ctx, deviceSchema, planValue, types.StringNull())
+	statePlan := testDeviceResourcePlan(t, ctx, deviceSchema, stateValue, types.StringNull())
+
+	response := &planmodifier.StringResponse{
+		PlanValue: planValue,
+	}
+	password.PlanModifiers[0].PlanModifyString(ctx, planmodifier.StringRequest{
+		ConfigValue: configValue,
+		Plan:        plan,
+		PlanValue:   planValue,
+		State: tfsdk.State{
+			Schema: deviceSchema,
+			Raw:    statePlan.Raw,
+		},
+		StateValue: stateValue,
+	}, response)
+
+	return response
 }
 
-data "xelon_tenant" "test" {}
-
-data "xelon_template" "test" {
-  cloud_id    = "e96db9d92ec7"
-  name        = "Debian 11"
-  most_recent = true
-}
-`, displayName, hostname, diskSize)
+func expectedDeviceMissingPasswordOrUserDataDiagnostics() diag.Diagnostics {
+	return diag.Diagnostics{
+		diag.NewAttributeErrorDiagnostic(
+			path.Root("password"),
+			"Missing password or user_data",
+			`Either "password" or "user_data" must be specified when creating or replacing a device.`,
+		),
+	}
 }

--- a/internal/provider/resource_xelon_dns_zone.go
+++ b/internal/provider/resource_xelon_dns_zone.go
@@ -101,7 +101,7 @@ func (r *dnsZoneResource) Create(ctx context.Context, request resource.CreateReq
 		Domain: data.Name.ValueString(),
 	}
 	tflog.Debug(ctx, "Creating dns zone", map[string]any{"payload": createRequest})
-	createDNSZone, _, err := r.client.Domains.CreateDNSZone(ctx, createRequest)
+	createDNSZone, _, err := r.client.Domains.CreateZone(ctx, createRequest)
 	if err != nil {
 		response.Diagnostics.AddError("Unable to create dns zone", err.Error())
 		return
@@ -128,7 +128,7 @@ func (r *dnsZoneResource) Read(ctx context.Context, request resource.ReadRequest
 
 	dnsZoneID := data.ID.ValueString()
 	tflog.Debug(ctx, "Getting dns zone", map[string]any{"dns_zone_id": dnsZoneID})
-	dnsZone, resp, err := r.client.Domains.GetDNSZone(ctx, dnsZoneID)
+	dnsZone, resp, err := r.client.Domains.GetZone(ctx, dnsZoneID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			// if the dns zone is somehow already destroyed, mark as successfully gone
@@ -164,7 +164,7 @@ func (r *dnsZoneResource) Delete(ctx context.Context, request resource.DeleteReq
 
 	dnsZoneID := data.ID.ValueString()
 	tflog.Debug(ctx, "Deleting dns zone", map[string]any{"dns_zone_id": dnsZoneID})
-	_, err := r.client.Domains.DeleteDNSZone(ctx, dnsZoneID)
+	_, err := r.client.Domains.DeleteZone(ctx, dnsZoneID)
 	if err != nil {
 		response.Diagnostics.AddError("Unable to delete dns zone", err.Error())
 		return

--- a/internal/provider/resource_xelon_dns_zone_test.go
+++ b/internal/provider/resource_xelon_dns_zone_test.go
@@ -26,11 +26,11 @@ func init() {
 				return err
 			}
 
-			dnsZones, errf := client.Domains.AllDNSZones(ctx, &xelon.ListOptions{PerPage: 100})
+			dnsZones, errf := client.Domains.AllZones(ctx, &xelon.ListOptions{PerPage: 100})
 			for dnsZone := range dnsZones {
 				if strings.HasPrefix(dnsZone.Name, accTestPrefix) {
 					slog.Info("Deleting xelon_dns_zone", "name", dnsZone.Name, "id", dnsZone.ID)
-					_, err := client.Domains.DeleteDNSZone(ctx, dnsZone.ID)
+					_, err := client.Domains.DeleteZone(ctx, dnsZone.ID)
 					if err != nil {
 						slog.Warn("Error deleting dns zone during sweep", "name", dnsZone.Name, "error", err)
 					}

--- a/internal/provider/resource_xelon_iso_test.go
+++ b/internal/provider/resource_xelon_iso_test.go
@@ -127,10 +127,10 @@ func TestAccResourceXelonISO_expectError(t *testing.T) {
 func testAccResourceXelonISOConfig(name string) string {
 	return fmt.Sprintf(`
 resource "xelon_iso" "test" {
-  category_id = 2
+  category_id = 7
   cloud_id    = data.xelon_cloud.test.id
   name        = %[1]q
-  url         = "https://cdimage.debian.org/releases/20.04.6/ubuntu-20.04.6-live-server-amd64.iso"
+  url         = "http://tinycorelinux.net/16.x/x86_64/release/TinyCorePure64-current.iso"
 }
 
 data "xelon_cloud" "test" {
@@ -143,11 +143,11 @@ data "xelon_cloud" "test" {
 func testAccResourceXelonISOConfigWithDescription(name, description string) string {
 	return fmt.Sprintf(`
 resource "xelon_iso" "test" {
-  category_id = 2
+  category_id = 7
   cloud_id    = data.xelon_cloud.test.id
   description = %[2]q
   name        = %[1]q
-  url         = "https://cdimage.debian.org/releases/20.04.6/ubuntu-20.04.6-live-server-amd64.iso"
+  url         = "http://tinycorelinux.net/16.x/x86_64/release/TinyCorePure64-current.iso"
 }
 
 data "xelon_cloud" "test" {
@@ -159,7 +159,7 @@ data "xelon_cloud" "test" {
 
 const testAccResourceXelonISOConfigWithoutName = `
 resource "xelon_iso" "test" {
-  category_id = 2
+  category_id = 7
   cloud_id    = "random-id"
   url         = "random-url"
 }
@@ -175,7 +175,7 @@ resource "xelon_iso" "test" {
 
 const testAccResourceXelonISOConfigWithoutURL = `
 resource "xelon_iso" "test" {
-  category_id = 2
+  category_id = 7
   cloud_id    = "random-id"
   name        = "random-name"
 }

--- a/internal/provider/resource_xelon_object_storage_access_key.go
+++ b/internal/provider/resource_xelon_object_storage_access_key.go
@@ -30,7 +30,7 @@ type objectStorageAccessKeyResource struct {
 	client *xelon.Client
 }
 
-// objectStorageUserResourceModel maps the object storage access key resource schema data.
+// objectStorageAccessKeyResourceModel maps the object storage access key resource schema data.
 type objectStorageAccessKeyResourceModel struct {
 	AccessKeyID         types.String `tfsdk:"access_key_id"`
 	CreatedAt           types.String `tfsdk:"created_at"`


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes `xelon_device` password handling for create-time device configuration.

  - makes password `Optional`, `Sensitive`, and replacement-only when configured
  - validates that either `password` or `user_data` is provided on create or replacement
  - avoids replacement for imported devices when password is omitted from config
  - keeps imported devices usable without knowing the original password
  - splits `xelon_device` unit tests from acceptance tests


### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

Fixes #66.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
