### PR TITLE
fix(resource/xelon_kubernetes_cluster): fix high availability lifecycle handling

### DIFF
--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -12,6 +12,10 @@ description: |-
 The kubernetes cluster resource allows you to manage Xelon Kubernetes (XKS) cluster.
 XKS is a Kubernetes service with a fully managed control plane and high availability.
 
+-> High availability can be configured independently for the control plane and load balancer
+when the cluster is created. After creation, only a full upgrade to high availability is supported,
+which enables HA for both components. High availability cannot be disabled on an existing cluster.
+
 ## Example Usage
 
 ### Minimal example
@@ -82,7 +86,7 @@ Optional:
 
 - `cpu_core_count` (Number) The number of CPU cores to allocate to control plane nodes. Defaults to `2`.
 - `disk_size` (Number) The size of the primary disk in GB. Defaults to `50`.
-- `high_availability_enabled` (Boolean) Whether to enable high availability (HA) mode. Defaults to `true`.
+- `high_availability_enabled` (Boolean) Whether to enable high availability (HA) for the control plane. Defaults to `true`. After creation, HA can only be enabled through a full-cluster upgrade affecting both the control plane and load balancer. Disabling HA is not supported.
 - `memory` (Number) The amount of RAM in GB to allocate to control plane nodes. Defaults to `4`.
 
 
@@ -93,7 +97,7 @@ Optional:
 
 - `cpu_core_count` (Number) The number of CPU cores to allocate to the load balancer. Defaults to `2`.
 - `disk_size` (Number) The size of the primary disk in GB. Defaults to `50`.
-- `high_availability_enabled` (Boolean) Whether to enable high availability (HA) mode. Defaults to `true`.
+- `high_availability_enabled` (Boolean) Whether to enable high availability (HA) for the load balancer. Defaults to `true`. After creation, HA can only be enabled through a full-cluster upgrade affecting both the control plane and load balancer. Disabling HA is not supported.
 - `memory` (Number) The amount of RAM in GB to allocate to the load balancer. Defaults to `4`.
 
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/Xelon-AG/xelon-sdk-go v1.13.2
+	github.com/Xelon-AG/xelon-sdk-go v1.13.3
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Xelon-AG/xelon-sdk-go v1.13.2 h1:bifbh1wujbX72X9ey3NYQKkUEahi8u+t7FFpCVlBgSc=
-github.com/Xelon-AG/xelon-sdk-go v1.13.2/go.mod h1:lkPHoPVkE0qCOvFO9phF4l8dBglxrrxyKlfAG3/VGBE=
+github.com/Xelon-AG/xelon-sdk-go v1.13.3 h1:0Gqk/PtjpRoYxViKChBdnF5fPsi3iYxM6clL10q7A8E=
+github.com/Xelon-AG/xelon-sdk-go v1.13.3/go.mod h1:lkPHoPVkE0qCOvFO9phF4l8dBglxrrxyKlfAG3/VGBE=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/provider/resource_xelon_kubernetes_cluster.go
+++ b/internal/provider/resource_xelon_kubernetes_cluster.go
@@ -107,10 +107,11 @@ XKS is a Kubernetes service with a fully managed control plane and high availabi
 						Default:             int64default.StaticInt64(50),
 					},
 					"high_availability_enabled": schema.BoolAttribute{
-						MarkdownDescription: "Whether to enable high availability (HA) mode. Defaults to `true`.",
-						Optional:            true,
-						Computed:            true,
-						Default:             booldefault.StaticBool(true),
+						MarkdownDescription: "Whether to enable high availability (HA) for the control plane. Defaults to `true`. " +
+							"After creation, HA can only be enabled through a full-cluster upgrade affecting both the control plane and load balancer. Disabling HA is not supported.",
+						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(true),
 					},
 					"memory": schema.Int64Attribute{
 						MarkdownDescription: "The amount of RAM in GB to allocate to control plane nodes. Defaults to `4`.",
@@ -153,10 +154,11 @@ XKS is a Kubernetes service with a fully managed control plane and high availabi
 						Default:             int64default.StaticInt64(50),
 					},
 					"high_availability_enabled": schema.BoolAttribute{
-						MarkdownDescription: "Whether to enable high availability (HA) mode. Defaults to `true`.",
-						Optional:            true,
-						Computed:            true,
-						Default:             booldefault.StaticBool(true),
+						MarkdownDescription: "Whether to enable high availability (HA) for the load balancer. Defaults to `true`. " +
+							"After creation, HA can only be enabled through a full-cluster upgrade affecting both the control plane and load balancer. Disabling HA is not supported.",
+						Optional: true,
+						Computed: true,
+						Default:  booldefault.StaticBool(true),
 					},
 					"memory": schema.Int64Attribute{
 						MarkdownDescription: "The amount of RAM in GB to allocate to the load balancer. Defaults to `4`.",

--- a/internal/provider/resource_xelon_kubernetes_cluster.go
+++ b/internal/provider/resource_xelon_kubernetes_cluster.go
@@ -24,8 +24,9 @@ import (
 )
 
 var (
-	_ resource.Resource              = (*kubernetesClusterResource)(nil)
-	_ resource.ResourceWithConfigure = (*kubernetesClusterResource)(nil)
+	_ resource.Resource               = (*kubernetesClusterResource)(nil)
+	_ resource.ResourceWithConfigure  = (*kubernetesClusterResource)(nil)
+	_ resource.ResourceWithModifyPlan = (*kubernetesClusterResource)(nil)
 )
 
 const (
@@ -57,6 +58,15 @@ type kubernetesClusterNodeSpecResourceModel struct {
 	Memory                  types.Int64 `tfsdk:"memory"`
 }
 
+type kubernetesClusterHATransition int
+
+const (
+	kubernetesClusterHAUnchanged kubernetesClusterHATransition = iota
+	kubernetesClusterHAUpgrade
+	kubernetesClusterHADowngrade
+	kubernetesClusterHAUnknown
+)
+
 func NewKubernetesClusterResource() resource.Resource { return &kubernetesClusterResource{} }
 
 func (r *kubernetesClusterResource) Metadata(_ context.Context, _ resource.MetadataRequest, response *resource.MetadataResponse) {
@@ -80,8 +90,8 @@ XKS is a Kubernetes service with a fully managed control plane and high availabi
 				Optional:            true,
 				Computed:            true,
 				Default: objectdefault.StaticValue(types.ObjectValueMust(
-					nodeSpecAttributeTypes(),
-					nodeSpecDefaultValues(),
+					kubernetesClusterNodeSpecAttributeTypes(),
+					kubernetesClusterNodeSpecDefaultValues(),
 				)),
 				Attributes: map[string]schema.Attribute{
 					"cpu_core_count": schema.Int64Attribute{
@@ -126,8 +136,8 @@ XKS is a Kubernetes service with a fully managed control plane and high availabi
 				Optional:            true,
 				Computed:            true,
 				Default: objectdefault.StaticValue(types.ObjectValueMust(
-					nodeSpecAttributeTypes(),
-					nodeSpecDefaultValues(),
+					kubernetesClusterNodeSpecAttributeTypes(),
+					kubernetesClusterNodeSpecDefaultValues(),
 				)),
 				Attributes: map[string]schema.Attribute{
 					"cpu_core_count": schema.Int64Attribute{
@@ -235,7 +245,6 @@ func (r *kubernetesClusterResource) Create(ctx context.Context, request resource
 	createRequest.ControlPlaneCPUCores = int(controlPlaneModel.CPUCoreCount.ValueInt64())
 	createRequest.ControlPlaneDiskSize = int(controlPlaneModel.DiskSize.ValueInt64())
 	createRequest.ControlPlaneRAM = int(controlPlaneModel.Memory.ValueInt64())
-	createRequest.ControlPlaneCPUCores = int(controlPlaneModel.CPUCoreCount.ValueInt64())
 	if controlPlaneModel.HighAvailabilityEnabled.ValueBool() {
 		createRequest.ControlPlaneType = "production"
 	} else {
@@ -251,7 +260,6 @@ func (r *kubernetesClusterResource) Create(ctx context.Context, request resource
 	createRequest.LoadBalancerCPUCores = int(loadBalancerModel.CPUCoreCount.ValueInt64())
 	createRequest.LoadBalancerDiskSize = int(loadBalancerModel.DiskSize.ValueInt64())
 	createRequest.LoadBalancerRAM = int(loadBalancerModel.Memory.ValueInt64())
-	createRequest.LoadBalancerCPUCores = int(loadBalancerModel.CPUCoreCount.ValueInt64())
 	if loadBalancerModel.HighAvailabilityEnabled.ValueBool() {
 		createRequest.LoadBalancerType = "production"
 	} else {
@@ -310,7 +318,7 @@ func (r *kubernetesClusterResource) Create(ctx context.Context, request resource
 		response.Diagnostics.AddError("Unable to get Kubernetes cluster load balancer", err.Error())
 		return
 	}
-	tflog.Debug(ctx, "Got Kubernetes load balancer data", map[string]any{"data": controlPlane})
+	tflog.Debug(ctx, "Got Kubernetes load balancer data", map[string]any{"data": loadBalancer})
 
 	// map response body to attributes
 	response.Diagnostics.Append(data.fromAPI(ctx, kubernetesCluster, controlPlane, loadBalancer)...)
@@ -351,7 +359,7 @@ func (r *kubernetesClusterResource) Read(ctx context.Context, request resource.R
 		response.Diagnostics.AddError("Unable to get Kubernetes cluster load balancer", err.Error())
 		return
 	}
-	tflog.Debug(ctx, "Got Kubernetes load balancer data", map[string]any{"data": controlPlane})
+	tflog.Debug(ctx, "Got Kubernetes load balancer data", map[string]any{"data": loadBalancer})
 
 	// map response body to attributes
 	response.Diagnostics.Append(data.fromAPI(ctx, kubernetesCluster, controlPlane, loadBalancer)...)
@@ -378,9 +386,29 @@ func (r *kubernetesClusterResource) Update(ctx context.Context, request resource
 	if response.Diagnostics.HasError() {
 		return
 	}
+	var planLoadBalancerModel kubernetesClusterNodeSpecResourceModel
+	response.Diagnostics.Append(plan.LoadBalancer.As(ctx, &planLoadBalancerModel, basetypes.ObjectAsOptions{})...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	var stateLoadBalancerModel kubernetesClusterNodeSpecResourceModel
+	response.Diagnostics.Append(state.LoadBalancer.As(ctx, &stateLoadBalancerModel, basetypes.ObjectAsOptions{})...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	response.Diagnostics.Append(validateKubernetesClusterHAChanges(
+		planControlPlaneModel,
+		stateControlPlaneModel,
+		planLoadBalancerModel,
+		stateLoadBalancerModel,
+	)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
 	// configure timeout
-	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultKubernetesNodePoolTimeout)
+	updateTimeout, diags := plan.Timeouts.Update(ctx, defaultKubernetesClusterTimeout)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -390,8 +418,52 @@ func (r *kubernetesClusterResource) Update(ctx context.Context, request resource
 
 	kubernetesClusterID := state.ID.ValueString()
 
-	if !planControlPlaneModel.HighAvailabilityEnabled.Equal(stateControlPlaneModel.HighAvailabilityEnabled) {
-		tflog.Warn(ctx, "Converting control plane to high-availability mode is not supported yet")
+	controlPlaneHATransition := kubernetesClusterHAChange(
+		planControlPlaneModel.HighAvailabilityEnabled,
+		stateControlPlaneModel.HighAvailabilityEnabled,
+	)
+	loadBalancerHATransition := kubernetesClusterHAChange(
+		planLoadBalancerModel.HighAvailabilityEnabled,
+		stateLoadBalancerModel.HighAvailabilityEnabled,
+	)
+	if controlPlaneHATransition == kubernetesClusterHAUpgrade || loadBalancerHATransition == kubernetesClusterHAUpgrade {
+		// validation above ensures the planned topology is full HA.
+		tflog.Debug(ctx, "upgrading Kubernetes cluster high availability", map[string]any{
+			"kubernetes_cluster_id": kubernetesClusterID,
+		})
+
+		tflog.Trace(ctx, "upgrading Kubernetes cluster high availability via API", map[string]any{
+			"kubernetes_cluster_id": kubernetesClusterID,
+		})
+		_, err := r.client.Kubernetes.UpgradeHighAvailability(ctx, kubernetesClusterID)
+		if err != nil {
+			response.Diagnostics.AddError("Unable to upgrade Kubernetes cluster to high availability", err.Error())
+			return
+		}
+
+		tflog.Info(ctx, "waiting for Kubernetes cluster to be ready", map[string]any{"kubernetes_cluster_id": kubernetesClusterID})
+		err = helper.WaitKubernetesClusterStatusReady(ctx, r.client, kubernetesClusterID, updateTimeout)
+		if err != nil {
+			// set id to state that the resource will be marked as tainted
+			response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), kubernetesClusterID)...)
+			response.Diagnostics.AddError("Unable to wait for Kubernetes cluster to be ready", err.Error())
+			return
+		}
+		tflog.Info(ctx, "Kubernetes cluster is ready", map[string]any{"kubernetes_cluster_id": kubernetesClusterID})
+
+		tflog.Info(ctx, "waiting for Kubernetes cluster to be healthy", map[string]any{"kubernetes_cluster_id": kubernetesClusterID})
+		err = helper.WaitKubernetesClusterControlPlaneStatusHealthy(ctx, r.client, kubernetesClusterID, updateTimeout)
+		if err != nil {
+			// set id to state that the resource will be marked as tainted
+			response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("id"), kubernetesClusterID)...)
+			response.Diagnostics.AddError("Unable to wait for Kubernetes cluster to be healthy", err.Error())
+			return
+		}
+		tflog.Info(ctx, "Kubernetes cluster is healthy", map[string]any{"kubernetes_cluster_id": kubernetesClusterID})
+
+		tflog.Debug(ctx, "upgraded Kubernetes cluster high availability", map[string]any{
+			"kubernetes_cluster_id": kubernetesClusterID,
+		})
 	}
 
 	if !planControlPlaneModel.CPUCoreCount.Equal(stateControlPlaneModel.CPUCoreCount) ||
@@ -449,7 +521,7 @@ func (r *kubernetesClusterResource) Update(ctx context.Context, request resource
 		response.Diagnostics.AddError("Unable to get Kubernetes cluster load balancer", err.Error())
 		return
 	}
-	tflog.Debug(ctx, "Got Kubernetes load balancer data", map[string]any{"data": controlPlane})
+	tflog.Debug(ctx, "Got Kubernetes load balancer data", map[string]any{"data": loadBalancer})
 
 	// map response body to attributes
 	response.Diagnostics.Append(plan.fromAPI(ctx, kubernetesCluster, controlPlane, loadBalancer)...)
@@ -477,22 +549,36 @@ func (r *kubernetesClusterResource) Delete(ctx context.Context, request resource
 	tflog.Debug(ctx, "Deleted Kubernetes cluster", map[string]any{"kubernetes_cluster_id": kubernetesClusterID})
 }
 
-func nodeSpecAttributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"cpu_core_count":            types.Int64Type,
-		"disk_size":                 types.Int64Type,
-		"high_availability_enabled": types.BoolType,
-		"memory":                    types.Int64Type,
+func (r *kubernetesClusterResource) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
+	if request.Plan.Raw.IsNull() || request.State.Raw.IsNull() {
+		return
 	}
-}
 
-func nodeSpecDefaultValues() map[string]attr.Value {
-	return map[string]attr.Value{
-		"cpu_core_count":            types.Int64Value(2),
-		"disk_size":                 types.Int64Value(50),
-		"high_availability_enabled": types.BoolValue(true),
-		"memory":                    types.Int64Value(4),
+	var plan, state kubernetesClusterResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
+	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
+	if response.Diagnostics.HasError() {
+		return
 	}
+
+	planControlPlane, diags := kubernetesClusterNodeSpecFromObject(ctx, plan.ControlPlane)
+	response.Diagnostics.Append(diags...)
+	stateControlPlane, diags := kubernetesClusterNodeSpecFromObject(ctx, state.ControlPlane)
+	response.Diagnostics.Append(diags...)
+	planLoadBalancer, diags := kubernetesClusterNodeSpecFromObject(ctx, plan.LoadBalancer)
+	response.Diagnostics.Append(diags...)
+	stateLoadBalancer, diags := kubernetesClusterNodeSpecFromObject(ctx, state.LoadBalancer)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	response.Diagnostics.Append(validateKubernetesClusterHAChanges(
+		planControlPlane,
+		stateControlPlane,
+		planLoadBalancer,
+		stateLoadBalancer,
+	)...)
 }
 
 func (m *kubernetesClusterResourceModel) fromAPI(ctx context.Context, kubernetesCluster *xelon.KubernetesCluster, controlPlane *xelon.KubernetesClusterControlPlane, loadBalancer *xelon.KubernetesClusterLoadBalancer) diag.Diagnostics {
@@ -507,7 +593,7 @@ func (m *kubernetesClusterResourceModel) fromAPI(ctx context.Context, kubernetes
 	}
 	m.CloudID = types.StringValue(cloudID)
 
-	controlPlaneModel, d := types.ObjectValueFrom(ctx, nodeSpecAttributeTypes(), kubernetesClusterNodeSpecResourceModel{
+	controlPlaneModel, d := types.ObjectValueFrom(ctx, kubernetesClusterNodeSpecAttributeTypes(), kubernetesClusterNodeSpecResourceModel{
 		CPUCoreCount:            types.Int64Value(int64(controlPlane.CPUCores)),
 		DiskSize:                types.Int64Value(int64(controlPlane.DiskSize)),
 		HighAvailabilityEnabled: types.BoolValue(len(controlPlane.Nodes) > 1),
@@ -516,7 +602,7 @@ func (m *kubernetesClusterResourceModel) fromAPI(ctx context.Context, kubernetes
 	diags.Append(d...)
 	m.ControlPlane = controlPlaneModel
 
-	loadBalancerModel, d := types.ObjectValueFrom(ctx, nodeSpecAttributeTypes(), kubernetesClusterNodeSpecResourceModel{
+	loadBalancerModel, d := types.ObjectValueFrom(ctx, kubernetesClusterNodeSpecAttributeTypes(), kubernetesClusterNodeSpecResourceModel{
 		CPUCoreCount:            types.Int64Value(int64(loadBalancer.CPUCores)),
 		DiskSize:                types.Int64Value(int64(loadBalancer.DiskSize)),
 		HighAvailabilityEnabled: types.BoolValue(len(loadBalancer.Instances) > 1),
@@ -526,4 +612,105 @@ func (m *kubernetesClusterResourceModel) fromAPI(ctx context.Context, kubernetes
 	m.LoadBalancer = loadBalancerModel
 
 	return diags
+}
+
+func kubernetesClusterNodeSpecAttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"cpu_core_count":            types.Int64Type,
+		"disk_size":                 types.Int64Type,
+		"high_availability_enabled": types.BoolType,
+		"memory":                    types.Int64Type,
+	}
+}
+
+func kubernetesClusterNodeSpecDefaultValues() map[string]attr.Value {
+	return map[string]attr.Value{
+		"cpu_core_count":            types.Int64Value(2),
+		"disk_size":                 types.Int64Value(50),
+		"high_availability_enabled": types.BoolValue(true),
+		"memory":                    types.Int64Value(4),
+	}
+}
+
+func kubernetesClusterNodeSpecFromObject(ctx context.Context, value types.Object) (kubernetesClusterNodeSpecResourceModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	model := kubernetesClusterNodeSpecResourceModel{
+		CPUCoreCount:            types.Int64Unknown(),
+		DiskSize:                types.Int64Unknown(),
+		HighAvailabilityEnabled: types.BoolUnknown(),
+		Memory:                  types.Int64Unknown(),
+	}
+	if value.IsNull() || value.IsUnknown() {
+		return model, diags
+	}
+
+	diags.Append(value.As(ctx, &model, basetypes.ObjectAsOptions{})...)
+	return model, diags
+}
+
+func validateKubernetesClusterHAChanges(planControlPlane, stateControlPlane, planLoadBalancer, stateLoadBalancer kubernetesClusterNodeSpecResourceModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	planControlPlaneHA := planControlPlane.HighAvailabilityEnabled
+	planLoadBalancerHA := planLoadBalancer.HighAvailabilityEnabled
+	controlPlaneTransition := kubernetesClusterHAChange(
+		planControlPlaneHA,
+		stateControlPlane.HighAvailabilityEnabled,
+	)
+	loadBalancerTransition := kubernetesClusterHAChange(
+		planLoadBalancerHA,
+		stateLoadBalancer.HighAvailabilityEnabled,
+	)
+
+	if controlPlaneTransition == kubernetesClusterHADowngrade {
+		diags.AddAttributeError(
+			path.Root("control_plane").AtName("high_availability_enabled"),
+			"Downgrading control plane high availability is not supported",
+			"High availability cannot be changed from true to false for an existing Kubernetes cluster.",
+		)
+	}
+
+	if loadBalancerTransition == kubernetesClusterHADowngrade {
+		diags.AddAttributeError(
+			path.Root("load_balancer").AtName("high_availability_enabled"),
+			"Downgrading load balancer high availability is not supported",
+			"High availability cannot be changed from true to false for an existing Kubernetes cluster.",
+		)
+	}
+
+	partialUpgradeDetail := "High availability upgrades enable both the control plane and load balancer. Set both high_availability_enabled values to true to upgrade the cluster."
+	planControlPlaneHAKnown := !planControlPlaneHA.IsNull() && !planControlPlaneHA.IsUnknown()
+	planLoadBalancerHAKnown := !planLoadBalancerHA.IsNull() && !planLoadBalancerHA.IsUnknown()
+	if controlPlaneTransition == kubernetesClusterHAUpgrade && planLoadBalancerHAKnown && !planLoadBalancerHA.ValueBool() {
+		diags.AddAttributeError(
+			path.Root("control_plane").AtName("high_availability_enabled"),
+			"Partial Kubernetes high availability upgrade is not supported",
+			partialUpgradeDetail,
+		)
+	}
+	if loadBalancerTransition == kubernetesClusterHAUpgrade && planControlPlaneHAKnown && !planControlPlaneHA.ValueBool() {
+		diags.AddAttributeError(
+			path.Root("load_balancer").AtName("high_availability_enabled"),
+			"Partial Kubernetes high availability upgrade is not supported",
+			partialUpgradeDetail,
+		)
+	}
+
+	return diags
+}
+
+func kubernetesClusterHAChange(planValue, stateValue types.Bool) kubernetesClusterHATransition {
+	if planValue.IsNull() || planValue.IsUnknown() || stateValue.IsNull() || stateValue.IsUnknown() {
+		return kubernetesClusterHAUnknown
+	}
+
+	switch {
+	case !stateValue.ValueBool() && planValue.ValueBool():
+		return kubernetesClusterHAUpgrade
+	case stateValue.ValueBool() && !planValue.ValueBool():
+		return kubernetesClusterHADowngrade
+	default:
+		return kubernetesClusterHAUnchanged
+	}
 }

--- a/internal/provider/resource_xelon_kubernetes_cluster_test.go
+++ b/internal/provider/resource_xelon_kubernetes_cluster_test.go
@@ -1,0 +1,283 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_CreateControlPlaneHADisabled(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA: types.BoolValue(false),
+		planLoadBalancerHA: types.BoolValue(true),
+		stateIsNull:        true,
+	})
+
+	assert.False(t, response.Diagnostics.HasError())
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_CreateLoadBalancerHADisabled(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA: types.BoolValue(true),
+		planLoadBalancerHA: types.BoolValue(false),
+		stateIsNull:        true,
+	})
+
+	assert.False(t, response.Diagnostics.HasError())
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_ControlPlaneHADowngrade(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolValue(false),
+		stateControlPlaneHA: types.BoolValue(true),
+		planLoadBalancerHA:  types.BoolValue(true),
+		stateLoadBalancerHA: types.BoolValue(true),
+	})
+
+	require.True(t, response.Diagnostics.HasError())
+	assert.True(t, response.Diagnostics.Equal(expectedKubernetesClusterControlPlaneHADowngradeDiagnostics()))
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_LoadBalancerHADowngrade(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolValue(true),
+		stateControlPlaneHA: types.BoolValue(true),
+		planLoadBalancerHA:  types.BoolValue(false),
+		stateLoadBalancerHA: types.BoolValue(true),
+	})
+
+	require.True(t, response.Diagnostics.HasError())
+	assert.True(t, response.Diagnostics.Equal(expectedKubernetesClusterLoadBalancerHADowngradeDiagnostics()))
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_ControlPlaneHAUpgrade_LoadBalancerAlreadyHA(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolValue(true),
+		stateControlPlaneHA: types.BoolValue(false),
+		planLoadBalancerHA:  types.BoolValue(true),
+		stateLoadBalancerHA: types.BoolValue(true),
+	})
+
+	assert.False(t, response.Diagnostics.HasError())
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_ControlPlaneHAPartialUpgrade(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolValue(true),
+		stateControlPlaneHA: types.BoolValue(false),
+		planLoadBalancerHA:  types.BoolValue(false),
+		stateLoadBalancerHA: types.BoolValue(false),
+	})
+
+	require.True(t, response.Diagnostics.HasError())
+	assert.True(t, response.Diagnostics.Equal(expectedKubernetesClusterControlPlaneHAPartialUpgradeDiagnostics()))
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_LoadBalancerHAUpgrade_ControlPlaneAlreadyHA(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolValue(true),
+		stateControlPlaneHA: types.BoolValue(true),
+		planLoadBalancerHA:  types.BoolValue(true),
+		stateLoadBalancerHA: types.BoolValue(false),
+	})
+
+	assert.False(t, response.Diagnostics.HasError())
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_LoadBalancerHAPartialUpgrade(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolValue(false),
+		stateControlPlaneHA: types.BoolValue(false),
+		planLoadBalancerHA:  types.BoolValue(true),
+		stateLoadBalancerHA: types.BoolValue(false),
+	})
+
+	require.True(t, response.Diagnostics.HasError())
+	assert.True(t, response.Diagnostics.Equal(expectedKubernetesClusterLoadBalancerHAPartialUpgradeDiagnostics()))
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_FullHAUpgrade(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolValue(true),
+		stateControlPlaneHA: types.BoolValue(false),
+		planLoadBalancerHA:  types.BoolValue(true),
+		stateLoadBalancerHA: types.BoolValue(false),
+	})
+
+	assert.False(t, response.Diagnostics.HasError())
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_HAUnchanged(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolValue(true),
+		stateControlPlaneHA: types.BoolValue(true),
+		planLoadBalancerHA:  types.BoolValue(false),
+		stateLoadBalancerHA: types.BoolValue(false),
+	})
+
+	assert.False(t, response.Diagnostics.HasError())
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_ControlPlaneHAUnknownPlanAllowed(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolUnknown(),
+		stateControlPlaneHA: types.BoolValue(false),
+		planLoadBalancerHA:  types.BoolValue(false),
+		stateLoadBalancerHA: types.BoolValue(false),
+	})
+
+	assert.False(t, response.Diagnostics.HasError())
+}
+
+func TestResourceXelonKubernetesCluster_ModifyPlan_LoadBalancerHAUnknownPlanAllowed(t *testing.T) {
+	response := testKubernetesClusterModifyPlanResponse(t, kubernetesClusterModifyPlanCase{
+		planControlPlaneHA:  types.BoolValue(false),
+		stateControlPlaneHA: types.BoolValue(false),
+		planLoadBalancerHA:  types.BoolUnknown(),
+		stateLoadBalancerHA: types.BoolValue(false),
+	})
+
+	assert.False(t, response.Diagnostics.HasError())
+}
+
+type kubernetesClusterModifyPlanCase struct {
+	planControlPlaneHA  types.Bool
+	planLoadBalancerHA  types.Bool
+	stateControlPlaneHA types.Bool
+	stateLoadBalancerHA types.Bool
+	stateIsNull         bool
+}
+
+type kubernetesClusterPlanValues struct {
+	controlPlaneHA types.Bool
+	loadBalancerHA types.Bool
+	id             types.String
+}
+
+func testKubernetesClusterModifyPlanResponse(t *testing.T, testCase kubernetesClusterModifyPlanCase) *resource.ModifyPlanResponse {
+	t.Helper()
+
+	ctx := context.Background()
+	kubernetesClusterSchema := testKubernetesClusterResourceSchema(t)
+
+	plan := testKubernetesClusterResourcePlan(t, ctx, kubernetesClusterSchema, kubernetesClusterPlanValues{
+		controlPlaneHA: testCase.planControlPlaneHA,
+		loadBalancerHA: testCase.planLoadBalancerHA,
+		id:             types.StringUnknown(),
+	})
+
+	state := tfsdk.State{
+		Schema: kubernetesClusterSchema,
+		Raw:    tftypes.NewValue(kubernetesClusterSchema.Type().TerraformType(ctx), nil),
+	}
+	if !testCase.stateIsNull {
+		statePlan := testKubernetesClusterResourcePlan(t, ctx, kubernetesClusterSchema, kubernetesClusterPlanValues{
+			controlPlaneHA: testCase.stateControlPlaneHA,
+			loadBalancerHA: testCase.stateLoadBalancerHA,
+			id:             types.StringValue("kubernetes-cluster-id"),
+		})
+		state.Raw = statePlan.Raw
+	}
+
+	response := &resource.ModifyPlanResponse{}
+	NewKubernetesClusterResource().(*kubernetesClusterResource).ModifyPlan(ctx, resource.ModifyPlanRequest{
+		Plan:  plan,
+		State: state,
+	}, response)
+
+	return response
+}
+
+func testKubernetesClusterResourceSchema(t *testing.T) schema.Schema {
+	t.Helper()
+
+	r := NewKubernetesClusterResource()
+	response := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, response)
+	require.False(t, response.Diagnostics.HasError())
+
+	return response.Schema
+}
+
+func testKubernetesClusterResourcePlan(t *testing.T, ctx context.Context, kubernetesClusterSchema schema.Schema, values kubernetesClusterPlanValues) tfsdk.Plan {
+	t.Helper()
+
+	plan := tfsdk.Plan{Schema: kubernetesClusterSchema}
+	diags := plan.Set(ctx, &kubernetesClusterResourceModel{
+		CloudID:           types.StringValue("cloud-id"),
+		ControlPlane:      testKubernetesClusterNodeSpecObject(values.controlPlaneHA),
+		ID:                values.id,
+		KubernetesVersion: types.StringValue("1.31.0"),
+		LoadBalancer:      testKubernetesClusterNodeSpecObject(values.loadBalancerHA),
+		Name:              types.StringValue("test-cluster"),
+		TalosVersion:      types.StringValue("1.9.0"),
+		TenantID:          types.StringValue("tenant-id"),
+		Timeouts: timeouts.Value{Object: types.ObjectNull(map[string]attr.Type{
+			"create": types.StringType,
+			"update": types.StringType,
+		})},
+	})
+	require.False(t, diags.HasError())
+
+	return plan
+}
+
+func testKubernetesClusterNodeSpecObject(highAvailabilityEnabled types.Bool) types.Object {
+	return types.ObjectValueMust(kubernetesClusterNodeSpecAttributeTypes(), map[string]attr.Value{
+		"cpu_core_count":            types.Int64Value(2),
+		"disk_size":                 types.Int64Value(50),
+		"high_availability_enabled": highAvailabilityEnabled,
+		"memory":                    types.Int64Value(4),
+	})
+}
+
+func expectedKubernetesClusterControlPlaneHADowngradeDiagnostics() diag.Diagnostics {
+	return diag.Diagnostics{
+		diag.NewAttributeErrorDiagnostic(
+			path.Root("control_plane").AtName("high_availability_enabled"),
+			"Downgrading control plane high availability is not supported",
+			"High availability cannot be changed from true to false for an existing Kubernetes cluster.",
+		),
+	}
+}
+
+func expectedKubernetesClusterLoadBalancerHADowngradeDiagnostics() diag.Diagnostics {
+	return diag.Diagnostics{
+		diag.NewAttributeErrorDiagnostic(
+			path.Root("load_balancer").AtName("high_availability_enabled"),
+			"Downgrading load balancer high availability is not supported",
+			"High availability cannot be changed from true to false for an existing Kubernetes cluster.",
+		),
+	}
+}
+
+func expectedKubernetesClusterControlPlaneHAPartialUpgradeDiagnostics() diag.Diagnostics {
+	return diag.Diagnostics{
+		diag.NewAttributeErrorDiagnostic(
+			path.Root("control_plane").AtName("high_availability_enabled"),
+			"Partial Kubernetes high availability upgrade is not supported",
+			"High availability upgrades enable both the control plane and load balancer. Set both high_availability_enabled values to true to upgrade the cluster.",
+		),
+	}
+}
+
+func expectedKubernetesClusterLoadBalancerHAPartialUpgradeDiagnostics() diag.Diagnostics {
+	return diag.Diagnostics{
+		diag.NewAttributeErrorDiagnostic(
+			path.Root("load_balancer").AtName("high_availability_enabled"),
+			"Partial Kubernetes high availability upgrade is not supported",
+			"High availability upgrades enable both the control plane and load balancer. Set both high_availability_enabled values to true to upgrade the cluster.",
+		),
+	}
+}

--- a/templates/resources/kubernetes_cluster.md.tmpl
+++ b/templates/resources/kubernetes_cluster.md.tmpl
@@ -10,6 +10,10 @@ description: |-
 
 {{ .Description | trimspace }}
 
+-> High availability can be configured independently for the control plane and load balancer
+when the cluster is created. After creation, only a full upgrade to high availability is supported,
+which enables HA for both components. High availability cannot be disabled on an existing cluster.
+
 ## Example Usage
 
 ### Minimal example


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR fixes `xelon_kubernetes_cluster` HA updates to match the Xelon backend lifecycle

- reject HA downgrades during planning
- reject partial post-create HA upgrades
- allow full HA upgrades

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
