### PR TITLE
fix(resource/xelon_object_storage_user): align computed field name for region replication

### DIFF
--- a/docs/resources/object_storage_user.md
+++ b/docs/resources/object_storage_user.md
@@ -44,5 +44,5 @@ resource "xelon_object_storage_user" "test" {
 ### Read-Only
 
 - `id` (String) The ID of the object storage user.
+- `region_replication_enabled` (Boolean) Whether region replication is enabled for the object storage user.
 - `s3_endpoints` (Set of String) The set of S3-compatible endpoint URLs that can be used to access object storage.
-- `zone_replication_enabled` (Boolean) Whether zone replication is enabled for the object storage user.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/Xelon-AG/xelon-sdk-go v1.13.3
+	github.com/Xelon-AG/xelon-sdk-go v1.14.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Xelon-AG/xelon-sdk-go v1.13.3 h1:0Gqk/PtjpRoYxViKChBdnF5fPsi3iYxM6clL10q7A8E=
-github.com/Xelon-AG/xelon-sdk-go v1.13.3/go.mod h1:lkPHoPVkE0qCOvFO9phF4l8dBglxrrxyKlfAG3/VGBE=
+github.com/Xelon-AG/xelon-sdk-go v1.14.0 h1:+kMCIKLTZFPfNuPgzyvyOnUVQMWupl+ArSaWX9Rtxh0=
+github.com/Xelon-AG/xelon-sdk-go v1.14.0/go.mod h1:lkPHoPVkE0qCOvFO9phF4l8dBglxrrxyKlfAG3/VGBE=
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=

--- a/internal/provider/resource_xelon_object_storage_user.go
+++ b/internal/provider/resource_xelon_object_storage_user.go
@@ -30,13 +30,13 @@ type objectStorageUserResource struct {
 
 // objectStorageUserResourceModel maps the object storage user resource schema data.
 type objectStorageUserResourceModel struct {
-	ID                     types.String `tfsdk:"id"`
-	Name                   types.String `tfsdk:"name"`
-	Region                 types.String `tfsdk:"region"`
-	S3Endpoints            types.Set    `tfsdk:"s3_endpoints"` // []types.String
-	StorageLimit           types.Int64  `tfsdk:"storage_limit"`
-	TenantID               types.String `tfsdk:"tenant_id"`
-	ZoneReplicationEnabled types.Bool   `tfsdk:"zone_replication_enabled"`
+	ID                       types.String `tfsdk:"id"`
+	Name                     types.String `tfsdk:"name"`
+	Region                   types.String `tfsdk:"region"`
+	RegionReplicationEnabled types.Bool   `tfsdk:"region_replication_enabled"`
+	S3Endpoints              types.Set    `tfsdk:"s3_endpoints"` // []types.String
+	StorageLimit             types.Int64  `tfsdk:"storage_limit"`
+	TenantID                 types.String `tfsdk:"tenant_id"`
 }
 
 func NewObjectStorageUserResource() resource.Resource {
@@ -77,6 +77,10 @@ Users are used to create access keys and manage access to Object Storage buckets
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"region_replication_enabled": schema.BoolAttribute{
+				MarkdownDescription: "Whether region replication is enabled for the object storage user.",
+				Computed:            true,
+			},
 			"s3_endpoints": schema.SetAttribute{
 				MarkdownDescription: "The set of S3-compatible endpoint URLs that can be used to access object storage.",
 				Computed:            true,
@@ -103,10 +107,6 @@ Users are used to create access keys and manage access to Object Storage buckets
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
 				},
-			},
-			"zone_replication_enabled": schema.BoolAttribute{
-				MarkdownDescription: "Whether zone replication is enabled for the object storage user.",
-				Computed:            true,
 			},
 		},
 	}
@@ -285,8 +285,8 @@ func (m *objectStorageUserResourceModel) fromAPI(ctx context.Context, objectStor
 	m.ID = types.StringValue(objectStorageUser.ID)
 	m.Name = types.StringValue(objectStorageUser.Name)
 	m.Region = types.StringValue(region)
+	m.RegionReplicationEnabled = types.BoolValue(objectStorageUser.RegionReplicationEnabled)
 	m.StorageLimit = types.Int64Value(int64(objectStorageUser.QuotaGB))
-	m.ZoneReplicationEnabled = types.BoolValue(objectStorageUser.ZoneReplicationEnabled)
 
 	if objectStorageUser.S3Endpoints == nil {
 		m.S3Endpoints = types.SetNull(types.StringType)

--- a/internal/provider/resource_xelon_object_storage_user_test.go
+++ b/internal/provider/resource_xelon_object_storage_user_test.go
@@ -73,6 +73,11 @@ func TestAccResourceXelonObjectStorageUser(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"xelon_object_storage_user.test",
+						tfjsonpath.New("region_replication_enabled"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_object_storage_user.test",
 						tfjsonpath.New("s3_endpoints"),
 						knownvalue.NotNull(),
 					),
@@ -84,11 +89,6 @@ func TestAccResourceXelonObjectStorageUser(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"xelon_object_storage_user.test",
 						tfjsonpath.New("tenant_id"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_object_storage_user.test",
-						tfjsonpath.New("zone_replication_enabled"),
 						knownvalue.NotNull(),
 					),
 				},
@@ -114,6 +114,11 @@ func TestAccResourceXelonObjectStorageUser(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"xelon_object_storage_user.test",
+						tfjsonpath.New("region_replication_enabled"),
+						knownvalue.NotNull(),
+					),
+					statecheck.ExpectKnownValue(
+						"xelon_object_storage_user.test",
 						tfjsonpath.New("s3_endpoints"),
 						knownvalue.NotNull(),
 					),
@@ -125,11 +130,6 @@ func TestAccResourceXelonObjectStorageUser(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"xelon_object_storage_user.test",
 						tfjsonpath.New("tenant_id"),
-						knownvalue.NotNull(),
-					),
-					statecheck.ExpectKnownValue(
-						"xelon_object_storage_user.test",
-						tfjsonpath.New("zone_replication_enabled"),
 						knownvalue.NotNull(),
 					),
 				},


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR aligns naming of computed field for `xelon_object_storage_user`: `zone_replication_enabled` -> `region_replication_enabled`.

### Checklist

- [x] Code is linted
- [x] Tested

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or
Closes #0000
--->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
  to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra
  noise for pull request followers and do not help prioritize the request
